### PR TITLE
Hooks accumulators

### DIFF
--- a/apps/ejabberd/src/amp_resolver.erl
+++ b/apps/ejabberd/src/amp_resolver.erl
@@ -11,8 +11,8 @@
 -include_lib("ejabberd/include/jlib.hrl").
 
 -spec verify_support(any(), amp_rules()) -> [ amp_rule_support() ].
-verify_support(HookAcc, Rules) ->
-    HookAcc ++ [ verify_rule_support(Rule) || Rule <- Rules ].
+verify_support(#{supported := Supp} = Acc, Rules) ->
+    maps:put(supported, Supp ++ [ verify_rule_support(Rule) || Rule <- Rules ], Acc).
 
 -spec verify_rule_support(amp_rule()) -> amp_rule_support().
 verify_rule_support(#amp_rule{action = alert} = Rule) ->

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -125,6 +125,7 @@ run(Hook, Host, Args) ->
 run_fold(Hook, Val, Args) ->
     run_fold(Hook, global, Val, Args).
 
+%%run_fold(Hook, Host, #{} = Val, Args) -> % now it MUST be a map
 run_fold(Hook, Host, Val, Args) ->
     case ets:lookup(hooks, {Hook, Host}) of
         [{_, Ls}] ->

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -111,7 +111,7 @@ run(Hook, Host, Args) ->
     case ets:lookup(hooks, {Hook, Host}) of
         [{_, Ls}] ->
             mongoose_metrics:increment_generic_hook_metric(Host, Hook),
-            run1(Ls, Hook, Args);
+            run1(Ls, Hook, #{}, Args); % run with empty map as accumulator
         [] ->
             ok
     end.
@@ -228,23 +228,25 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%----------------------------------------------------------------------
 
-run1([], _Hook, _Args) ->
-    ok;
-run1([{_Seq, Module, Function} | Ls], Hook, Args) ->
+run1([], _Hook, Acc, _Args) ->
+    Acc;
+run1([{_Seq, Module, Function} | Ls], Hook, Acc, Args) ->
     Res = if is_function(Function) ->
-                  safely:apply(Function, Args);
+                  safely:apply(Function, [Acc|Args]);
              true ->
-                  safely:apply(Module, Function, Args)
+                  safely:apply(Module, Function, [Acc|Args])
           end,
     case Res of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p~n    Running hook: ~p~n    Callback: ~p:~p",
                        [Reason, {Hook, Args}, Module, Function]),
-            run1(Ls, Hook, Args);
+            run1(Ls, Hook, Acc, Args);
         stop ->
-            ok;
-        _ ->
-            run1(Ls, Hook, Args)
+            stopped;
+        {stop, NAcc} ->
+            NAcc;
+        NewAcc ->
+            run1(Ls, Hook, NewAcc, Args)
     end.
 
 run_fold1([], _Hook, Val, _Args) ->

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -45,12 +45,13 @@
          unregister_host/1,
          unregister_iq_response_handler/2,
          refresh_iq_handlers/0,
-         bounce_resource_packet/3
+         bounce_resource_packet/3,
+         bounce_resource_packet/4
         ]).
 
 %% Hooks callbacks
 
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -226,6 +227,14 @@ unregister_iq_handler(Host, XMLNS) ->
 refresh_iq_handlers() ->
     ejabberd_local ! refresh_iq_handlers.
 
+%% #rh
+-spec bounce_resource_packet(Acc:: map(), From :: ejabberd:jid(),
+    To :: ejabberd:jid(),
+    Packet :: jlib:xmlel()) -> {'stop', map()}.
+bounce_resource_packet(Acc, From, To, Packet) ->
+    bounce_resource_packet(From, To, Packet),
+    {stop, Acc}.
+
 -spec bounce_resource_packet(From :: ejabberd:jid(),
                              To :: ejabberd:jid(),
                              Packet :: jlib:xmlel()) -> 'stop'.
@@ -246,7 +255,7 @@ unregister_host(Host) ->
 %% API
 %%====================================================================
 
-node_cleanup(Node) ->
+node_cleanup(Acc, Node) ->
     F = fun() ->
                 Keys = mnesia:select(
                          iq_response,
@@ -257,7 +266,8 @@ node_cleanup(Node) ->
                                       mnesia:delete({iq_response, Key})
                               end, Keys)
         end,
-    mnesia:async_dirty(F).
+    Res = mnesia:async_dirty(F),
+    maps:put(cleanup_result, Res, Acc).
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -50,7 +50,7 @@
         ]).
 
 %% Hooks callbacks
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -157,7 +157,7 @@ dirty_get_connections() ->
 %% Hooks callbacks
 %%====================================================================
 
-node_cleanup(Node) ->
+node_cleanup(Acc, Node) ->
     F = fun() ->
                 Es = mnesia:select(
                        s2s,
@@ -168,7 +168,8 @@ node_cleanup(Node) ->
                                       mnesia:delete_object(E)
                               end, Es)
         end,
-    mnesia:async_dirty(F).
+    Res = mnesia:async_dirty(F),
+    maps:put(cleanup_result, Res, Acc).
 
 -spec key({ejabberd:lserver(), ejabberd:lserver()}, binary()) ->
     binary().

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -35,8 +35,8 @@
          close_session/5,
          store_info/4,
          check_in_subscription/6,
-         bounce_offline_message/3,
-         disconnect_removed_user/2,
+         bounce_offline_message/4,
+         disconnect_removed_user/3,
          get_user_resources/2,
          set_presence/7,
          unset_presence/6,
@@ -60,7 +60,7 @@
         ]).
 
 %% Hook handlers
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -207,23 +207,32 @@ check_in_subscription(Acc, User, Server, _JID, _Type, _Reason) ->
     end.
 
 
--spec bounce_offline_message(From, To, Packet) -> stop when
+%% #rh
+-spec bounce_offline_message(Acc, From, To, Packet) -> {stop, Acc} when
+      Acc :: map(),
       From :: ejabberd:jid(),
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel().
+bounce_offline_message(Acc, From, To, Packet) ->
+    bounce_offline_message(From, To, Packet),
+    {stop, Acc}.
+
 bounce_offline_message(#jid{server = Server} = From, To, Packet) ->
     ejabberd_hooks:run(xmpp_bounce_message,
-                       Server,
-                       [Server, Packet]),
+        Server,
+        [Server, Packet]),
     Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
     ejabberd_router:route(To, From, Err),
     stop.
 
--spec disconnect_removed_user(User :: ejabberd:user(), Server :: ejabberd:server()) -> ok.
-disconnect_removed_user(User, Server) ->
+%% #rh
+-spec disconnect_removed_user(map(), User :: ejabberd:user(),
+                              Server :: ejabberd:server()) -> map().
+disconnect_removed_user(Acc, User, Server) ->
     ejabberd_sm:route(jid:make(<<>>, <<>>, <<>>),
                       jid:make(User, Server, <<>>),
-                      {broadcast, {exit, <<"User removed">>}}).
+                      {broadcast, {exit, <<"User removed">>}}),
+    Acc.
 
 
 -spec get_user_resources(User :: ejabberd:user(), Server :: ejabberd:server()) -> [binary()].
@@ -387,9 +396,10 @@ unregister_iq_handler(Host, XMLNS) ->
 %% Hook handlers
 %%====================================================================
 
-node_cleanup(Node) ->
+node_cleanup(Acc, Node) ->
     Timeout = timer:minutes(1),
-    gen_server:call(?MODULE, {node_cleanup, Node}, Timeout).
+    Res = gen_server:call(?MODULE, {node_cleanup, Node}, Timeout),
+    maps:put(cleanup_result, Res, Acc).
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -7,7 +7,7 @@
          does_user_exist/2]).
 
 %% Hooks.
--export([remove_user/2]).
+-export([remove_user/3]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -87,11 +87,12 @@ does_user_exist(LUser, LServer) ->
 %% Hooks
 %%====================================================================
 
--spec remove_user(LUser :: ejabberd:luser(),
-                  LServer :: ejabberd:lserver() | string()) -> ok.
-remove_user(LUser, LServer) ->
+-spec remove_user(Acc :: map(),
+                  LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver() | string()) -> map().
+remove_user(Acc, LUser, LServer) ->
     delete_user(LUser, LServer),
-    ok.
+    Acc.
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/mod_adhoc.erl
+++ b/apps/ejabberd/src/mod_adhoc.erl
@@ -144,9 +144,9 @@ get_sm_commands(Acc, _From, _To, _Node, _Lang) ->
                          To :: ejabberd:jid(),
                          NS :: binary(),
                          ejabberd:lang()) -> {result, [jlib:xmlel()]} | [jlib:xmlel()].
-get_local_identity(#{local_identity := Ids} = Acc, From, To, Ns, Lang) ->
+get_local_identity(Acc, From, To, Ns, Lang) ->
     LId = do_get_local_identity(From, To, Ns, Lang),
-    maps:put(local_identity, Ids ++ LId, Acc).
+    mongoose_perdix:append(local_identity, LId, Acc).
 
 do_get_local_identity(_From, _To, ?NS_COMMANDS, Lang) ->
     [#xmlel{name = <<"identity">>,

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -66,8 +66,8 @@ check_packet(Packet, _, _) ->
 
 add_local_features(Acc, _From, _To, ?NS_AMP, _Lang) ->
     Features = result_or(Acc, []) ++ amp_features(),
-    Features = maps:get(features, Acc, []) ++ amp_features(),
-    maps:put(features, Features, Acc);
+    Features = mongoose_perdix:get(features, Acc, []) ++ amp_features(),
+    mongoose_perdix:put(features, Features, Acc);
 add_local_features(Acc, _From, _To, _NS, _Lang) ->
     Acc.
 

--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -26,7 +26,7 @@
          terminate/3]).
 
 %% Hooks callbacks
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% For testing and debugging
 -export([get_session_socket/1, store_session/2]).
@@ -135,8 +135,9 @@ stop(_Host) ->
 %% Hooks handlers
 %%--------------------------------------------------------------------
 
-node_cleanup(Node) ->
-    ?BOSH_BACKEND:node_cleanup(Node).
+node_cleanup(Acc, Node) ->
+    Res = ?BOSH_BACKEND:node_cleanup(Node),
+    maps:put(cleanup_result, Res, Acc).
 
 %%--------------------------------------------------------------------
 %% cowboy_loop_handler callbacks

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -487,10 +487,11 @@ caps_delete_fun(Node) ->
 
 make_my_disco_hash(Host) ->
     JID = jid:make(<<"">>, Host, <<"">>),
-    A1 = ejabberd_hooks:run_fold(disco_local_features, Host, #{}, [JID, JID, <<"">>, <<"">>]),
+    A0 = mongoose_perdix:new(),
+    A1 = ejabberd_hooks:run_fold(disco_local_features, Host, A0, [JID, JID, <<"">>, <<"">>]),
     A2 = ejabberd_hooks:run_fold(disco_local_identity, Host, A1, [JID, JID, <<"">>, <<"">>]),
     A3 = ejabberd_hooks:run_fold(disco_info, Host, A2, [Host, undefined, <<"">>, <<"">>]),
-    case A3 of
+    case mongoose_perdix:to_map(A3) of
         #{features := Features, identities := Identities, info := Info} ->
             Feats = lists:map(fun ({{Feat, _Host}}) ->
                                       #xmlel{name = <<"feature">>,

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -46,7 +46,7 @@
 -export([init/1, handle_info/2, handle_call/3,
          handle_cast/2, terminate/2, code_change/3]).
 
--export([user_send_packet/3, user_receive_packet/4,
+-export([user_send_packet/4, user_receive_packet/5,
          c2s_presence_in/2, c2s_filter_packet/6,
          c2s_broadcast_recipients/6]).
 
@@ -144,11 +144,12 @@ read_caps([_ | Tail], Result) ->
     read_caps(Tail, Result);
 read_caps([], Result) -> Result.
 
-user_send_packet(#jid{luser = User, lserver = Server} = From,
+user_send_packet(Acc,
+                 #jid{luser = User, lserver = Server} = From,
                  #jid{luser = User, lserver = Server,
                       lresource = <<"">>},
                  #xmlel{name = <<"presence">>, attrs = Attrs,
-                        children = Els} = Pkt) ->
+                        children = Els}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
     if Type == <<"">>; Type == <<"available">> ->
             case read_caps(Els) of
@@ -158,13 +159,13 @@ user_send_packet(#jid{luser = User, lserver = Server} = From,
             end;
        true -> ok
     end,
-    Pkt;
-user_send_packet(_From, _To, Pkt) ->
-    Pkt.
+    Acc;
+user_send_packet(Acc, _From, _To, _Pkt) ->
+    Acc.
 
-user_receive_packet(#jid{lserver = Server}, From, _To,
+user_receive_packet(Acc, #jid{lserver = Server}, From, _To,
                     #xmlel{name = <<"presence">>, attrs = Attrs,
-                           children = Els} = Pkt) ->
+                           children = Els}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
     IsRemote = not lists:member(From#jid.lserver, ?MYHOSTS),
     if IsRemote and
@@ -176,9 +177,9 @@ user_receive_packet(#jid{lserver = Server}, From, _To,
             end;
        true -> ok
     end,
-    Pkt;
-user_receive_packet(_JID, _From, _To, Pkt) ->
-    Pkt.
+    Acc;
+user_receive_packet(Acc, _JID, _From, _To, _Pkt) ->
+    Acc.
 
 -spec caps_stream_features([xmlel()], binary()) -> [xmlel()].
 

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -36,11 +36,11 @@
          classify_packet/1]).
 
 %% Hooks
--export([user_send_packet/3,
-         user_receive_packet/4,
+-export([user_send_packet/4,
+         user_receive_packet/5,
          iq_handler2/3,
          iq_handler1/3,
-         remove_connection/4
+         remove_connection/5
         ]).
 
 %% For testing and debugging
@@ -116,11 +116,13 @@ iq_handler(From, _To,  #iq{type = set, sub_el = #xmlel{name = Operation, childre
 iq_handler(_From, _To, IQ, _CC) ->
     IQ#iq{type=error, sub_el = [?ERR_NOT_ALLOWED]}.
 
-user_send_packet(From, To, Packet) ->
-    check_and_forward(From, To, Packet, sent).
+user_send_packet(Acc, From, To, Packet) ->
+    check_and_forward(From, To, Packet, sent),
+    Acc.
 
-user_receive_packet(JID, _From, To, Packet) ->
-    check_and_forward(JID, To, Packet, received).
+user_receive_packet(Acc, JID, _From, To, Packet) ->
+    check_and_forward(JID, To, Packet, received),
+    Acc.
 
 % Check if the traffic is local.
 % Modified from original version:
@@ -181,15 +183,15 @@ is_forwarded(SubTag) ->
         _ -> ignore
     end.
 
-remove_connection(User, Server, Resource, _Status) ->
+remove_connection(Acc, User, Server, Resource, _Status) ->
     disable(Server, User, Resource),
-    ok.
+    Acc.
 
 
 %%
 %% Internal
 %%
-is_bare_to(Direction, To, PrioRes) ->
+is_bare_to(Direction, To, _PrioRes) ->
     case {Direction, To} of
         {received, #jid{lresource = <<>>}} -> true;
         _ -> false

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -56,7 +56,7 @@
 -include_lib("ejabberd/include/jlib.hrl").
 
 -type classification() :: 'ignore' | 'forward'.
--type matchspec_atom() :: '_' | '$1' | '$2' | '$3'.
+%%-type matchspec_atom() :: '_' | '$1' | '$2' | '$3'.
 
 is_carbon_copy(Packet) ->
     case xml:get_subtag(Packet, <<"sent">>) of
@@ -197,11 +197,11 @@ is_bare_to(Direction, To, _PrioRes) ->
         _ -> false
     end.
 
-is_unavailable(LRes, PrioRes) ->
-    case lists:keyfind(LRes, 2, PrioRes) of
-        false -> true;
-        _ -> false
-    end.
+%%is_unavailable(LRes, PrioRes) ->
+%%    case lists:keyfind(LRes, 2, PrioRes) of
+%%        false -> true;
+%%        _ -> false
+%%    end.
 
 max_prio(PrioRes) ->
     case catch lists:max(PrioRes) of

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -202,7 +202,7 @@ get_recent_messages(Caller, Before, Limit) ->
     get_recent_messages(Caller, undefined, Before, Limit).
 
 get_recent_messages(Caller, With, 0, Limit) ->
-    {MegaSecs, Secs, _} = now(),
+    {MegaSecs, Secs, _} = os:timestamp(),
     Future = (MegaSecs + 1) * 1000000 + Secs, % to make sure we return all messages
     get_recent_messages(Caller, With, Future, Limit);
 get_recent_messages(Caller, With, Before, Limit) ->

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -163,7 +163,7 @@ registered_users(Host) ->
 
 register(Host, User, Password) ->
     case ejabberd_auth:try_register(User, Host, Password) of
-        ok ->
+        #{} ->
             list_to_binary(io_lib:format("User ~s@~s successfully registered", [User, Host]));
         {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",

--- a/apps/ejabberd/src/mod_csi.erl
+++ b/apps/ejabberd/src/mod_csi.erl
@@ -29,8 +29,9 @@ stop(Host) ->
 hooks() ->
     [{c2s_stream_features, ?MODULE, add_csi_feature, 60}].
 
-add_csi_feature(Acc, _Host) ->
-    lists:keystore(<<"csi">>, #xmlel.name, Acc, csi()).
+add_csi_feature(#{features := Feat} = Acc, _Host) ->
+    NFeat = lists:keystore(<<"csi">>, #xmlel.name, Feat, csi()),
+    maps:put(features, NFeat, Acc).
 
 csi() ->
     #xmlel{name = <<"csi">>,

--- a/apps/ejabberd/src/mod_disco.erl
+++ b/apps/ejabberd/src/mod_disco.erl
@@ -142,9 +142,9 @@ process_local_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} =
 
             case ejabberd_hooks:run_fold(disco_local_items,
                                          Host,
-                                         empty,
+                                         #{local_items => []},
                                          [From, To, Node, Lang]) of
-                {result, Items} ->
+                #{local_items := Items} ->
                     ANode = case Node of
                                 <<>> -> [];
                                 _ -> [{<<"node">>, Node}]
@@ -169,17 +169,18 @@ process_local_iq_info(From, To, #iq{type = Type, lang = Lang,
         get ->
             Host = To#jid.lserver,
             Node = xml:get_tag_attr_s(<<"node">>, SubEl),
-            Identity = ejabberd_hooks:run_fold(disco_local_identity,
+            A1 = #{local_identity => [], info => [], features => []},
+            A2 = ejabberd_hooks:run_fold(disco_local_identity,
                                                Host,
-                                               [],
+                                               A1,
                                                [From, To, Node, Lang]),
-            Info = ejabberd_hooks:run_fold(disco_info, Host, [],
+            A3 = ejabberd_hooks:run_fold(disco_info, Host, A2,
                                            [Host, ?MODULE, Node, Lang]),
             case ejabberd_hooks:run_fold(disco_local_features,
                                          Host,
-                                         empty,
+                                         A3,
                                          [From, To, Node, Lang]) of
-                {result, Features} ->
+                #{features := Features, info := Info, local_identity := Identity} ->
                     ANode = case Node of
                                 <<>> -> [];
                                 _ -> [{<<"node">>, Node}]
@@ -196,41 +197,47 @@ process_local_iq_info(From, To, #iq{type = Type, lang = Lang,
     end.
 
 
--spec get_local_identity(Acc :: [jlib:xmlel()],
+-spec get_local_identity(Acc :: map(),
                         From :: ejabberd:jid(),
                         To :: ejabberd:jid(),
                         Node :: binary(),
                         Lang :: ejabberd:lang()) -> [jlib:xmlel()].
-get_local_identity(Acc, _From, _To, <<>>, _Lang) ->
-    Acc ++ [#xmlel{name = <<"identity">>,
+get_local_identity(#{local_identity := Ids} = Acc, _From, _To, <<>>, _Lang) ->
+    NIds = Ids ++ [#xmlel{name = <<"identity">>,
                    attrs = [{<<"category">>, <<"server">>},
                             {<<"type">>, <<"im">>},
-                            {<<"name">>, <<"ejabberd">>}]}];
+                            {<<"name">>, <<"ejabberd">>}]}],
+    maps:put(local_identity, NIds, Acc);
 get_local_identity(Acc, _From, _To, Node, _Lang) when is_binary(Node) ->
     Acc.
 
 
--spec get_local_features(Acc :: 'empty' | {'error',_} | {'result',_},
+-spec get_local_features(Acc :: map(),% | {'error',_} | {'result',_},
                         From :: ejabberd:jid(),
                         To :: ejabberd:jid(),
                         Node :: binary(),
                         Lang :: ejabberd:lang()) -> {'error',_} | {'result',_}.
-get_local_features({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
-    Acc;
+%%get_local_features({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
+%%    Acc;
 get_local_features(Acc, _From, To, <<>>, _Lang) ->
-    Feats = case Acc of
-                {result, Features} -> Features;
-                empty -> []
-            end,
+%%    Feats = case Acc of
+%%                {result, Features} -> Features;
+%%                empty -> []
+%%            end,
+    Feats = maps:get(features, Acc, []),
     Host = To#jid.lserver,
-    {result,
-     ets:select(disco_features, [{{{'_', Host}}, [], ['$_']}]) ++ Feats};
+    NFeats = ets:select(disco_features, [{{{'_', Host}}, [], ['$_']}]) ++ Feats,
+    maps:put(features, NFeats, Acc);
+
+%%    {result,
+%%     ets:select(disco_features, [{{{'_', Host}}, [], ['$_']}]) ++ Feats};
 get_local_features(Acc, _From, _To, Node, _Lang) when is_binary(Node) ->
-    case Acc of
-        {result, _Features} ->
-            Acc;
-        empty ->
-            {error, ?ERR_ITEM_NOT_FOUND}
+    #{features := F} = Acc,
+    case F of
+        [] ->
+            {error, ?ERR_ITEM_NOT_FOUND};
+        [_|_] ->
+            Acc
     end.
 
 
@@ -255,26 +262,27 @@ domain_to_xml(Domain) ->
     #xmlel{name = <<"item">>, attrs = [{<<"jid">>, Domain}]}.
 
 
--spec get_local_services(Acc :: 'empty' | {'error',_} | {'result',_},
+-spec get_local_services(Acc :: map(),
                          From :: ejabberd:jid(),
                          To :: ejabberd:jid(),
                          Node :: binary(),
                          Lang :: ejabberd:lang()) -> {'error',_} | {'result',_}.
-get_local_services({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
-    Acc;
+%%get_local_services({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
+%%    Acc;
 get_local_services(Acc, _From, To, <<>>, _Lang) ->
-    Items = case Acc of
-                {result, Its} -> Its;
-                empty -> []
-            end,
-    Host = To#jid.lserver,
-    {result,
-     lists:usort(
+%%    Items = case Acc of
+%%                {result, Its} -> Its;
+%%                empty -> []
+%%            end,
+     Items = maps:get(local_items, Acc, []),
+     Host = To#jid.lserver,
+     NItems = lists:usort(
        lists:map(fun domain_to_xml/1,
                  get_vh_services(Host) ++
                  ets:select(disco_extra_domains,
                             [{{{'$1', Host}}, [], ['$1']}]))
-       ) ++ Items};
+       ) ++ Items,
+     maps:put(local_items, NItems, Acc);
 get_local_services({result, _} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_local_services(empty, _From, _To, _Node, _Lang) ->
@@ -392,15 +400,15 @@ process_sm_iq_info(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ)
                 true ->
                     Host = To#jid.lserver,
                     Node = xml:get_tag_attr_s(<<"node">>, SubEl),
-                    Identity = ejabberd_hooks:run_fold(disco_sm_identity,
+                    #{sm_identity := Identity} = ejabberd_hooks:run_fold(disco_sm_identity,
                                                        Host,
-                                                       [],
+                                                       #{sm_identity => []},
                                                        [From, To, Node, Lang]),
                     case ejabberd_hooks:run_fold(disco_sm_features,
                                                  Host,
-                                                 empty,
+                                                 #{sm_features => []},
                                                  [From, To, Node, Lang]) of
-                        {result, Features} ->
+                        #{sm_features := Features} ->
                             ANode = case Node of
                                         <<>> -> [];
                                         _ -> [{<<"node">>, Node}]
@@ -419,28 +427,29 @@ process_sm_iq_info(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ)
     end.
 
 
--spec get_sm_identity(Acc :: [jlib:xmlel()],
+-spec get_sm_identity(Acc :: map(),
                       From :: ejabberd:jid(),
                       To :: ejabberd:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> [jlib:xmlel()].
-get_sm_identity(Acc, _From, #jid{luser = LUser, lserver=LServer}, _Node, _Lang) ->
-    Acc ++  case ejabberd_auth:is_user_exists(LUser, LServer) of
-        true ->
-           [#xmlel{name = <<"identity">>,
-                   attrs = [{<<"category">>, <<"account">>},
-  {<<"type">>, <<"registered">>}]}];
-       _ ->
-           []
-           end.
+get_sm_identity(#{sm_identity := Ids} = Acc, _From, #jid{luser = LUser, lserver=LServer}, _Node, _Lang) ->
+    Id = case ejabberd_auth:is_user_exists(LUser, LServer) of
+            true ->
+               [#xmlel{name = <<"identity">>, attrs = [{<<"category">>, <<"account">>},
+                      {<<"type">>, <<"registered">>}]}
+               ];
+            _ ->
+               []
+         end,
+    maps:put(sm_identity, Ids ++ Id, Acc).
 
 
--spec get_sm_features(empty | any(),
+-spec get_sm_features(map(),
                       From :: ejabberd:jid(),
                       To :: ejabberd:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> any().
-get_sm_features(empty, From, To, _Node, _Lang) ->
+get_sm_features(#{sm_features := []}, From, To, _Node, _Lang) ->
     #jid{luser = LFrom, lserver = LSFrom} = From,
     #jid{luser = LTo, lserver = LSTo} = To,
     case {LFrom, LSFrom} of
@@ -468,7 +477,7 @@ get_user_resources(User, Server) ->
 
 -spec get_info(A :: [jlib:xmlel()], ejabberd:server(), module(), Node :: binary(),
         Lang :: ejabberd:lang()) -> [jlib:xmlel()].
-get_info(_A, Host, Mod, Node, _Lang) when Node == [] ->
+get_info(Acc, Host, Mod, Node, _Lang) when Node == [] ->
     Module = case Mod of
                  undefined ->
                      ?MODULE;
@@ -476,13 +485,14 @@ get_info(_A, Host, Mod, Node, _Lang) when Node == [] ->
                      Mod
              end,
     Serverinfo_fields = get_fields_xml(Host, Module),
-    [#xmlel{name = <<"x">>,
+    Info = [#xmlel{name = <<"x">>,
             attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"result">>}],
             children = [#xmlel{name = <<"field">>,
                                attrs = [{<<"var">>, <<"FORM_TYPE">>}, {<<"type">>, <<"hidden">>}],
                                children = [#xmlel{name = <<"value">>,
                                                   children = [#xmlcdata{content = ?NS_SERVERINFO}]}]}]
-                     ++ Serverinfo_fields}];
+                     ++ Serverinfo_fields}],
+    maps:put(info, Info, Acc);
 get_info(Acc, _, _, _Node, _) ->
     Acc.
 

--- a/apps/ejabberd/src/mod_disco.erl
+++ b/apps/ejabberd/src/mod_disco.erl
@@ -140,11 +140,16 @@ process_local_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} =
             Node = xml:get_tag_attr_s(<<"node">>, SubEl),
             Host = To#jid.lserver,
 
-            case ejabberd_hooks:run_fold(disco_local_items,
+            Acc = mongoose_perdix:new(),
+            Acc2 = ejabberd_hooks:run_fold(disco_local_items,
                                          Host,
-                                         #{local_items => []},
-                                         [From, To, Node, Lang]) of
-                #{local_items := Items} ->
+                                         Acc2,
+                                         [From, To, Node, Lang]),
+            case Acc2 of
+                {error, Error} ->
+                    IQ#iq{type = error, sub_el = [SubEl, Error]};
+                _ ->
+                    Items = mongoose_perdix:get(local_items, Acc2, []),
                     ANode = case Node of
                                 <<>> -> [];
                                 _ -> [{<<"node">>, Node}]
@@ -152,9 +157,7 @@ process_local_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} =
                     IQ#iq{type = result,
                           sub_el = [#xmlel{name = <<"query">>,
                                            attrs = [{<<"xmlns">>, ?NS_DISCO_ITEMS} | ANode],
-                                           children = Items}]};
-                {error, Error} ->
-                    IQ#iq{type = error, sub_el = [SubEl, Error]}
+                                           children = Items}]}
             end
     end.
 
@@ -208,8 +211,7 @@ get_local_identity(Acc, _From, _To, <<>>, _Lang) ->
                    attrs = [{<<"category">>, <<"server">>},
                             {<<"type">>, <<"im">>},
                             {<<"name">>, <<"ejabberd">>}]}],
-    mongoose_perdix:append(local_identity, NIds, Acc).
-
+    mongoose_perdix:append(local_identity, NIds, Acc);
 get_local_identity(Acc, _From, _To, Node, _Lang) when is_binary(Node) ->
     Acc.
 
@@ -226,10 +228,10 @@ get_local_features(Acc, _From, To, <<>>, _Lang) ->
 %%                {result, Features} -> Features;
 %%                empty -> []
 %%            end,
-    Feats = maps:get(features, Acc, []),
+    Feats = mongoose_perdix:get(features, Acc, []),
     Host = To#jid.lserver,
     NFeats = ets:select(disco_features, [{{{'_', Host}}, [], ['$_']}]) ++ Feats,
-    maps:put(features, NFeats, Acc);
+    mongoose_perdix:put(features, NFeats, Acc);
 
 %%    {result,
 %%     ets:select(disco_features, [{{{'_', Host}}, [], ['$_']}]) ++ Feats};
@@ -276,15 +278,15 @@ get_local_services(Acc, _From, To, <<>>, _Lang) ->
 %%                {result, Its} -> Its;
 %%                empty -> []
 %%            end,
-     Items = maps:get(local_items, Acc, []),
+%%     Items = maps:get(local_items, Acc, []),
      Host = To#jid.lserver,
      NItems = lists:usort(
        lists:map(fun domain_to_xml/1,
                  get_vh_services(Host) ++
                  ets:select(disco_extra_domains,
                             [{{{'$1', Host}}, [], ['$1']}]))
-       ) ++ Items,
-     maps:put(local_items, NItems, Acc);
+       ),
+     mongoose_perdix:append(local_items, NItems, Acc);
 get_local_services({result, _} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_local_services(empty, _From, _To, _Node, _Lang) ->
@@ -321,11 +323,15 @@ process_sm_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ
                 true ->
                     Host = To#jid.lserver,
                     Node = xml:get_tag_attr_s(<<"node">>, SubEl),
+                    Acc = mongoose_perdix:new(),
                     case ejabberd_hooks:run_fold(disco_sm_items,
                                                  Host,
-                                                 empty,
+                                                 Acc,
                                                  [From, To, Node, Lang]) of
-                        {result, Items} ->
+                        {error, Error} ->
+                            IQ#iq{type = error, sub_el = [SubEl, Error]};
+                        Acc1 ->
+                            Items = mongoose_perdix:get(sm_items, Acc1, []),
                             ANode = case Node of
                                         <<>> -> [];
                                         _ -> [{<<"node">>, Node}]
@@ -333,9 +339,7 @@ process_sm_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ
                             IQ#iq{type = result,
                                   sub_el = [#xmlel{name = <<"query">>,
                                                    attrs = [{<<"xmlns">>, ?NS_DISCO_ITEMS} | ANode],
-                                                   children = Items}]};
-                        {error, Error} ->
-                            IQ#iq{type = error, sub_el = [SubEl, Error]}
+                                                   children = Items}]}
                     end;
                 false ->
                     IQ#iq{type = error, sub_el = [SubEl, ?ERR_SERVICE_UNAVAILABLE]}
@@ -352,18 +356,24 @@ get_sm_items({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_sm_items(Acc, From,
             #jid{user = User, server = Server} = To,
-            [], _Lang) ->
-    Items = case Acc of
-                {result, Its} -> Its;
-                empty -> []
-            end,
-    Items1 = case is_presence_subscribed(From, To) of
-                   true ->
-                       get_user_resources(User, Server);
-                   _ ->
-                       []
-                end,
-    {result, Items ++ Items1};
+            [], Lang) ->
+%%    Items = case Acc of
+%%                {result, Its} -> Its;
+%%                empty -> []
+%%            end,
+    Items = mongoose_perdix:get(sm_items, Acc, []),
+    case Items of
+        [] ->
+            get_sm_items(empty, From, To, [], Lang);
+        _ ->
+            Items1 = case is_presence_subscribed(From, To) of
+                           true ->
+                               get_user_resources(User, Server);
+                           _ ->
+                               []
+                        end,
+            mongoose_perdix:append(sm_items, Items1, Acc)
+    end;
 get_sm_items({result, _} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_sm_items(empty, From, To, _Node, _Lang) ->
@@ -402,15 +412,21 @@ process_sm_iq_info(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ)
                 true ->
                     Host = To#jid.lserver,
                     Node = xml:get_tag_attr_s(<<"node">>, SubEl),
-                    #{sm_identity := Identity} = ejabberd_hooks:run_fold(disco_sm_identity,
+                    Acc = mongoose_perdix:new(),
+                    Acc1 = ejabberd_hooks:run_fold(disco_sm_identity,
                                                        Host,
-                                                       #{sm_identity => []},
+                                                       Acc,
                                                        [From, To, Node, Lang]),
-                    case ejabberd_hooks:run_fold(disco_sm_features,
+                    Acc2 = ejabberd_hooks:run_fold(disco_sm_features,
                                                  Host,
-                                                 #{sm_features => []},
-                                                 [From, To, Node, Lang]) of
-                        #{sm_features := Features} ->
+                                                 Acc1,
+                                                 [From, To, Node, Lang]),
+                    case Acc2 of
+                        {error, Error} ->
+                            IQ#iq{type = error, sub_el = [SubEl, Error]};
+                        _ ->
+                            Features = mongoose_perdix:get(sm_features, Acc2, []),
+                            Identity = mongoose_perdix:get(sm_identity, Acc2, []),
                             ANode = case Node of
                                         <<>> -> [];
                                         _ -> [{<<"node">>, Node}]
@@ -419,9 +435,7 @@ process_sm_iq_info(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ)
                                   sub_el = [#xmlel{name = <<"query">>,
                                                    attrs = [{<<"xmlns">>, ?NS_DISCO_INFO} | ANode],
                                                    children = Identity ++
-                                                              features_to_xml(Features)}]};
-                        {error, Error} ->
-                            IQ#iq{type = error, sub_el = [SubEl, Error]}
+                                                              features_to_xml(Features)}]}
                     end;
                 false ->
                     IQ#iq{type = error, sub_el = [SubEl, ?ERR_SERVICE_UNAVAILABLE]}
@@ -434,7 +448,8 @@ process_sm_iq_info(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ)
                       To :: ejabberd:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> [jlib:xmlel()].
-get_sm_identity(#{sm_identity := Ids} = Acc, _From, #jid{luser = LUser, lserver=LServer}, _Node, _Lang) ->
+get_sm_identity(Acc, _From, #jid{luser = LUser, lserver=LServer}, _Node, _Lang) ->
+    Ids = mongoose_perdix:get(sm_identity, Acc, []),
     Id = case ejabberd_auth:is_user_exists(LUser, LServer) of
             true ->
                [#xmlel{name = <<"identity">>, attrs = [{<<"category">>, <<"account">>},
@@ -443,7 +458,7 @@ get_sm_identity(#{sm_identity := Ids} = Acc, _From, #jid{luser = LUser, lserver=
             _ ->
                []
          end,
-    maps:put(sm_identity, Ids ++ Id, Acc).
+    mongoose_perdix:put(sm_identity, Ids ++ Id, Acc).
 
 
 -spec get_sm_features(map(),
@@ -451,14 +466,19 @@ get_sm_identity(#{sm_identity := Ids} = Acc, _From, #jid{luser = LUser, lserver=
                       To :: ejabberd:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> any().
-get_sm_features(#{sm_features := []}, From, To, _Node, _Lang) ->
-    #jid{luser = LFrom, lserver = LSFrom} = From,
-    #jid{luser = LTo, lserver = LSTo} = To,
-    case {LFrom, LSFrom} of
-        {LTo, LSTo} ->
-            {error, ?ERR_ITEM_NOT_FOUND};
+get_sm_features(Acc, From, To, _Node, _Lang) ->
+    case mongoose_perdix:get(sm_features, Acc, []) of
+        [] ->
+            #jid{luser = LFrom, lserver = LSFrom} = From,
+            #jid{luser = LTo, lserver = LSTo} = To,
+            case {LFrom, LSFrom} of
+                {LTo, LSTo} ->
+                    {error, ?ERR_ITEM_NOT_FOUND};
+                _ ->
+                    {error, ?ERR_NOT_ALLOWED}
+            end;
         _ ->
-            {error, ?ERR_NOT_ALLOWED}
+            Acc
     end;
 get_sm_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
@@ -494,7 +514,7 @@ get_info(Acc, Host, Mod, Node, _Lang) when Node == [] ->
                                children = [#xmlel{name = <<"value">>,
                                                   children = [#xmlcdata{content = ?NS_SERVERINFO}]}]}]
                      ++ Serverinfo_fields}],
-    maps:put(info, Info, Acc);
+    mongoose_perdix:append(info, Info, Acc);
 get_info(Acc, _, _, _Node, _) ->
     Acc.
 

--- a/apps/ejabberd/src/mod_http_notification.erl
+++ b/apps/ejabberd/src/mod_http_notification.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_mod).
 
 %% API
--export([start/2, stop/1, on_user_send_packet/3, should_make_req/3]).
+-export([start/2, stop/1, on_user_send_packet/4, should_make_req/3]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -31,7 +31,7 @@ stop(Host) ->
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, on_user_send_packet, 100),
     ok.
 
-on_user_send_packet(From, To, Packet) ->
+on_user_send_packet(Acc, From, To, Packet) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
     Mod = get_callback_module(),
     case Mod:should_make_req(Packet, From, To) of
@@ -39,7 +39,8 @@ on_user_send_packet(From, To, Packet) ->
             make_req(From#jid.lserver, From#jid.luser, To#jid.luser, Body);
         _ ->
             ok
-    end.
+    end,
+    Acc.
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -36,12 +36,12 @@
          stop/1,
          process_local_iq/3,
          process_sm_iq/3,
-         on_presence_update/4,
+         on_presence_update/5,
          store_last_info/4,
          get_last_info/2,
          count_active_users/2,
-         remove_user/2,
-         session_cleanup/4
+         remove_user/3,
+         session_cleanup/5
         ]).
 
 -include("ejabberd.hrl").
@@ -223,11 +223,14 @@ get_last(LUser, LServer) ->
 count_active_users(LServer, Timestamp) ->
     ?BACKEND:count_active_users(LServer, Timestamp).
 
--spec on_presence_update(ejabberd:user(), ejabberd:server(), ejabberd:resource(),
-                         Status :: binary()) -> ok | {error, term()}.
-on_presence_update(LUser, LServer, _Resource, Status) ->
+-spec on_presence_update(map(), ejabberd:user(), ejabberd:server(), ejabberd:resource(),
+                         Status :: binary()) -> map() | {error, term()}.
+on_presence_update(Acc, LUser, LServer, _Resource, Status) ->
     TimeStamp = now_to_seconds(os:timestamp()),
-    store_last_info(LUser, LServer, TimeStamp, Status).
+    case store_last_info(LUser, LServer, TimeStamp, Status) of
+        ok -> Acc;
+        E -> E
+    end.
 
 -spec store_last_info(ejabberd:user(), ejabberd:server(), non_neg_integer(),
                       Status :: binary()) -> ok | {error, term()}.
@@ -242,14 +245,21 @@ get_last_info(LUser, LServer) ->
         Res -> Res
     end.
 
--spec remove_user(ejabberd:user(), ejabberd:server()) -> ok | {error, term()}.
-remove_user(User, Server) ->
+%% #rh
+-spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map() | {error, term()}.
+remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    ?BACKEND:remove_user(LUser, LServer).
+    case ?BACKEND:remove_user(LUser, LServer) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec session_cleanup(LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
+-spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(LUser, LServer, LResource, _SID) ->
-    on_presence_update(LUser, LServer, LResource, <<>>).
+session_cleanup(Acc, LUser, LServer, LResource, _SID) ->
+    case on_presence_update(Acc, LUser, LServer, LResource, <<>>) of
+        Acc when is_map(Acc) -> Acc;
+        E -> E
+    end.
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -46,8 +46,8 @@
 
 %% ejabberd handlers
 -export([process_mam_iq/3,
-         user_send_packet/3,
-         remove_user/2,
+         user_send_packet/4,
+         remove_user/3,
          filter_packet/1,
          determine_amp_strategy/5,
          sm_filter_offline_message/4]).
@@ -274,13 +274,14 @@ process_mam_iq(From=#jid{lserver=Host}, To, IQ) ->
 %%
 %% Note: for outgoing messages, the server MUST use the value of the 'to'
 %%       attribute as the target JID.
--spec user_send_packet(From :: ejabberd:jid(), To :: ejabberd:jid(),
-                       Packet :: jlib:xmlel()) -> 'ok'.
-user_send_packet(From, To, Packet) ->
+-spec user_send_packet(Acc :: map(), From :: ejabberd:jid(),
+                       To :: ejabberd:jid(),
+                       Packet :: jlib:xmlel()) -> map().
+user_send_packet(Acc, From, To, Packet) ->
     ?DEBUG("Send packet~n    from ~p ~n    to ~p~n    packet ~p.",
               [From, To, Packet]),
     handle_package(outgoing, false, From, To, From, Packet),
-    ok.
+    Acc.
 
 
 %% @doc Handle an incoming message.
@@ -322,9 +323,11 @@ process_incoming_packet(From, To, Packet) ->
     handle_package(incoming, true, To, From, From, Packet).
 
 %% @doc A ejabberd's callback with diferent order of arguments.
--spec remove_user(ejabberd:user(), ejabberd:server()) -> 'ok'.
-remove_user(User, Server) ->
-    delete_archive(Server, User).
+%% #rh
+-spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map().
+remove_user(Acc, User, Server) ->
+    delete_archive(Server, User),
+    Acc.
 
 sm_filter_offline_message(_Drop=false, _From, _To, Packet) ->
     %% If ...

--- a/apps/ejabberd/src/mod_mam_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_cache_user.erl
@@ -19,7 +19,7 @@
 %% ejabberd handlers
 -export([cached_archive_id/3,
          store_archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 %% API
 -export([clean_cache/1]).
@@ -168,10 +168,13 @@ store_archive_id(UserID, _Host, ArcJID) ->
     UserID.
 
 
--spec remove_archive(_Host :: ejabberd:server(), _UserID :: ejabberd:user(),
-                    ArcJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(_Host, _UserID, ArcJID) ->
-    clean_cache(ArcJID).
+%% #rh
+-spec remove_archive(Acc :: map(), _Host :: ejabberd:server(),
+                     _UserID :: ejabberd:user(),
+                     ArcJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, _Host, _UserID, ArcJID) ->
+    clean_cache(ArcJID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
@@ -20,6 +20,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
+         remove_archive/4,
          remove_archive/3]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
@@ -204,13 +205,16 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _ArcID, ArcJID) ->
             {DefaultMode, AlwaysJIDs, NeverJIDs}
     end.
 
+%% #rh
+remove_archive(Host, ArcID, ArcJID) ->
+    remove_archive(ok, Host, ArcID, ArcJID).
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> any().
-remove_archive(_Host, _ArcID, ArcJID) ->
+remove_archive(Acc, _Host, _ArcID, ArcJID) ->
     SU = su_key(ArcJID),
     mnesia:sync_dirty(fun() ->
             mnesia:delete(mam_prefs, SU, write)
-        end).
+        end),
+    Acc.
 
 %% ----------------------------------------------------------------------
 %% Helpers

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -47,7 +47,8 @@
 %% ejabberd room handlers
 -export([filter_room_packet/2,
          room_process_mam_iq/3,
-         forget_room/2]).
+         forget_room/2,
+         forget_room/3]).
 
 %% private
 -export([archive_message/8]).
@@ -314,6 +315,13 @@ room_process_mam_iq(From=#jid{lserver=Host}, To, IQ) ->
         false -> return_action_not_allowed_error_iq(IQ)
     end.
 
+
+%% #rh
+%% @doc This hook is called from `mod_muc:forget_room(Host, Name)'.
+-spec forget_room(map(), ejabberd:lserver(), binary()) -> map().
+forget_room(Acc, LServer, RoomName) ->
+    forget_room(LServer, RoomName),
+    Acc.
 
 %% @doc This hook is called from `mod_muc:forget_room(Host, Name)'.
 -spec forget_room(ejabberd:lserver(), binary()) -> 'ok'.

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -22,7 +22,7 @@
 %%% Message identifiers (or UIDs in the spec) are generated based on:
 %%%
 %%% <ul>
-%%% <li>date (using `now()');</li>
+%%% <li>date (using `os:timestamp()');</li>
 %%% <li>node number (using {@link ejabberd_node_id}).</li>
 %%% </ul>
 %%% @end
@@ -370,7 +370,11 @@ is_user_identity_hidden(From, ArcJID) ->
 
 -spec can_access_room(From :: ejabberd:jid(), To :: ejabberd:jid()) -> boolean().
 can_access_room(From, To) ->
-    ejabberd_hooks:run_fold(can_access_room, To#jid.lserver, false, [From, To]).
+    #{can_access_room := Can} = ejabberd_hooks:run_fold(can_access_room,
+                                                        To#jid.lserver,
+                                                        #{can_access_room => false},
+                                                        [From, To]),
+    Can.
 
 
 -spec action_type(action()) -> 'get' | 'set'.
@@ -487,7 +491,7 @@ handle_lookup_messages(
         From=#jid{},
         ArcJID=#jid{},
         IQ=#iq{xmlns = MamNs, sub_el = QueryEl}) ->
-    Now = mod_mam_utils:now_to_microseconds(now()),
+    Now = mod_mam_utils:now_to_microseconds(os:timestamp()),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = xml:get_tag_attr_s(<<"queryid">>, QueryEl),
@@ -542,7 +546,7 @@ handle_set_message_form(
         From=#jid{},
         ArcJID=#jid{},
         IQ=#iq{xmlns=MamNs, sub_el = QueryEl}) ->
-    Now = mod_mam_utils:now_to_microseconds(now()),
+    Now = mod_mam_utils:now_to_microseconds(os:timestamp()),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = xml:get_tag_attr_s(<<"queryid">>, QueryEl),
@@ -628,7 +632,7 @@ handle_get_message_form(_From=#jid{}, _ArcJID=#jid{}, IQ=#iq{}) ->
     ejabberd:iq() | {error, any(), ejabberd:iq()}.
 handle_purge_multiple_messages(ArcJID=#jid{},
                                IQ=#iq{sub_el = PurgeEl}) ->
-    Now = mod_mam_utils:now_to_microseconds(now()),
+    Now = mod_mam_utils:now_to_microseconds(os:timestamp()),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     %% Filtering by date.
@@ -648,7 +652,7 @@ handle_purge_multiple_messages(ArcJID=#jid{},
     ejabberd:iq() | {error, any(), ejabberd:iq()}.
 handle_purge_single_message(ArcJID=#jid{},
                             IQ=#iq{sub_el = PurgeEl}) ->
-    Now = mod_mam_utils:now_to_microseconds(now()),
+    Now = mod_mam_utils:now_to_microseconds(os:timestamp()),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     BExtMessID = xml:get_tag_attr_s(<<"id">>, PurgeEl),

--- a/apps/ejabberd/src/mod_mam_muc_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cache_user.erl
@@ -21,7 +21,7 @@
 %% ejabberd handlers
 -export([cached_archive_id/3,
          store_archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 %% API
 -export([clean_cache/1]).
@@ -117,8 +117,10 @@ store_archive_id(UserID, _Host, ArcJID) ->
     maybe_cache_archive_id(ArcJID, UserID),
     UserID.
 
-remove_archive(_Host, _UserID, ArcJID) ->
-    clean_cache(ArcJID).
+%% #rh
+remove_archive(Acc, _Host, _UserID, ArcJID) ->
+    clean_cache(ArcJID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -19,6 +19,7 @@
          archive_message/9,
          lookup_messages/14,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -194,13 +195,13 @@ archive_messages(LServer, Acc, N) ->
            "(id, room_id, nick_name, message) "
        "VALUES ", tuples(Acc)]).
 
-lookup_messages({error, Reason}=Result, _Host,
+lookup_messages({error, _Reason}=Result, _Host,
                 _UserID, _UserJID, _RSM, _Borders,
                 _Start, _End, _Now, _WithJID,
                 _PageSize, _LimitPassed, _MaxResultLimit,
                 _IsSimple) ->
     Result;
-lookup_messages(Result, Host,
+lookup_messages(_Result, Host,
                 UserID, UserJID, RSM, Borders,
                 Start, End, Now, WithJID,
                 PageSize, LimitPassed, MaxResultLimit,
@@ -414,15 +415,17 @@ row_to_message_id({BMessID,_,_}) ->
     list_to_integer(binary_to_list(BMessID)).
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> 'ok'.
-remove_archive(Host, RoomID, _RoomJID) ->
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> map().
+remove_archive(Acc, Host, RoomID, _RoomJID) ->
     {updated, _} =
     mod_mam_utils:success_sql_query(
       Host,
       ["DELETE FROM ", select_table(RoomID), " "
        "WHERE room_id = '", escape_room_id(RoomID), "'"]),
-    ok.
+    Acc.
 
+remove_archive(Host, RoomID, RoomJID) ->
+    remove_archive(ok, Host, RoomID, RoomJID).
 
 -spec purge_single_message(_Result, Host :: ejabberd:server(),
                            MessID :: mod_mam:message_id(),

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -17,7 +17,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -253,10 +253,11 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
     Result.
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> 'ok'.
-remove_archive(Host, ArcID, _ArcJID) ->
+%% #rh
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> map().
+remove_archive(Acc, Host, ArcID, _ArcJID) ->
     wait_flushing(Host, ArcID),
-    ok.
+    Acc.
 
 
 -spec purge_single_message(ejabberd_gen_mam_archive:purge_single_message_result(),

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -23,7 +23,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -521,15 +521,17 @@ row_to_message_id({BMessID,_,_}) ->
     list_to_integer(binary_to_list(BMessID)).
 
 
--spec remove_archive(Host :: ejabberd:server(), ArchiveID :: mod_mam:archive_id(),
-        RoomJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, UserID, _UserJID) ->
+%% #rh
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     ArchiveID :: mod_mam:archive_id(),
+                     RoomJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, UserID, _UserJID) ->
     {updated, _} =
     mod_mam_utils:success_sql_query(
       Host,
       ["DELETE FROM ", select_table(UserID), " "
        "WHERE user_id = '", escape_user_id(UserID), "'"]),
-    ok.
+    Acc.
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
                            MessID :: mod_mam:message_id(),

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -18,6 +18,7 @@
          archive_message/9,
          lookup_messages/14,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -259,12 +260,16 @@ lookup_messages(Result, Host, ArcID, _ArcJID,
     Result.
 
 
--spec remove_archive(Host :: ejabberd:server(),
-        RoomId :: mod_mam:archive_id(), RoomJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, ArcID, _ArcJID) ->
+%% #rh
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     RoomId :: mod_mam:archive_id(),
+                     RoomJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, ArcID, _ArcJID) ->
     wait_flushing(Host, ArcID),
-    ok.
+    Acc.
 
+remove_archive(Host, ArcID, _ArcJID) ->
+    wait_flushing(Host, ArcID).
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
         MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -17,7 +17,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
-         remove_archive/3]).
+         remove_archive/4]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
 -include_lib("ejabberd/include/jlib.hrl").
@@ -188,9 +188,10 @@ get_prefs({GlobalDefaultMode, _, _}, Host, UserID, _ArcJID) ->
     decode_prefs_rows(Rows, GlobalDefaultMode, [], []).
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(),
-                     ejabberd:jid()) -> 'ok'.
-remove_archive(Host, UserID, _ArcJID) ->
+%% #rh
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(),
+                     ejabberd:jid()) -> map().
+remove_archive(Acc, Host, UserID, _ArcJID) ->
     SUserID = integer_to_list(UserID),
     {updated, _} =
     mod_mam_utils:success_sql_query(
@@ -198,7 +199,7 @@ remove_archive(Host, UserID, _ArcJID) ->
       ["DELETE "
        "FROM mam_config "
        "WHERE user_id='", SUserID, "'"]),
-    ok.
+    Acc.
 
 
 -spec query_behaviour(ejabberd:server(), SUserID :: string(),

--- a/apps/ejabberd/src/mod_mam_odbc_user.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_user.erl
@@ -15,7 +15,7 @@
 
 %% ejabberd handlers
 -export([archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -124,9 +124,10 @@ archive_id(undefined, Host, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
 archive_id(ArcID, _Host, _ArcJID) ->
     ArcID.
 
--spec remove_archive(Host :: ejabberd:server(),
-    ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     ArchiveID :: mod_mam:archive_id(),
+                     ArchiveJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
     SUserName = ejabberd_odbc:escape(UserName),
     SServer   = ejabberd_odbc:escape(Server),
     {updated, _} =
@@ -134,7 +135,7 @@ remove_archive(Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) -
       Host,
       ["DELETE FROM mam_server_user "
        "WHERE server = '", SServer, "' AND user_name = '", SUserName, "'"]),
-    ok.
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -27,6 +27,7 @@
          archive_size/4,
          lookup_messages/10,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -310,6 +311,10 @@ get_message2(MsgId, Bucket, Key) ->
         _ ->
             []
     end.
+
+remove_archive(Acc, Host, ArchiveID, ArchiveJID) ->
+    remove_archive(Host, ArchiveID, ArchiveJID),
+    Acc.
 
 remove_archive(Host, _ArchiveID, ArchiveJID) ->
     {ok, TotalCount, _, _} = R = remove_chunk(Host, ArchiveJID, 0),

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -634,7 +634,7 @@ find_field([#xmlel{name = <<"field">>, attrs = Attrs}=Field|Fields], Name) ->
     end;
 find_field([_|Fields], Name) -> %% skip whitespaces
     find_field(Fields, Name);
-find_field([], Name) ->
+find_field([], _Name) ->
     undefined.
 
 -spec field_to_value(jlib:xmlel()) -> binary().
@@ -821,7 +821,7 @@ maybe_previous_id(X) ->
     TotalCount  :: non_neg_integer()|undefined,
     Offset      :: non_neg_integer()|undefined,
     MessageRows :: list().
-is_last_page(PageSize, TotalCount, Offset, MessageRows)
+is_last_page(PageSize, _TotalCount, _Offset, MessageRows)
     when length(MessageRows) < PageSize ->
     true;
 is_last_page(PageSize, TotalCount, Offset, MessageRows)

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -541,7 +541,7 @@ route_by_type(<<"iq">>, {From, To, Packet}, #state{host = Host} = State) ->
     ServerHost = State#state.server_host,
     case jlib:iq_query_info(Packet) of
         #iq{type = get, xmlns = ?NS_DISCO_INFO = XMLNS, lang = Lang} = IQ ->
-            Info = ejabberd_hooks:run_fold(disco_info, ServerHost, [],
+            #{info := Info} = ejabberd_hooks:run_fold(disco_info, ServerHost, #{},
                                            [ServerHost, ?MODULE, "", Lang]),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
@@ -840,7 +840,8 @@ xfield(Type, Label, Var, Val, Lang) ->
 %%       http://xmpp.org/extensions/xep-0045.html#createroom-unique
 -spec iq_get_unique(ejabberd:jid()) -> jlib:xmlcdata().
 iq_get_unique(From) ->
-        #xmlcdata{content = sha:sha1_hex(term_to_binary([From, now(), randoms:get_string()]))}.
+        #xmlcdata{content = sha:sha1_hex(term_to_binary([From, os:timestamp(),
+                                                         randoms:get_string()]))}.
 
 
 -spec iq_get_register_info('undefined' | ejabberd:server(),
@@ -1119,11 +1120,12 @@ is_room_owner(_, Room, User) ->
 muc_room_pid(_, Room) ->
     room_jid_to_pid(Room).
 
--spec can_access_room(Acc :: boolean(), From :: ejabberd:jid(), To :: ejabberd:jid()) ->
+-spec can_access_room(Acc :: map(), From :: ejabberd:jid(), To :: ejabberd:jid()) ->
     boolean().
-can_access_room(_, From, To) ->
-    case mod_muc_room:can_access_room(To, From) of
+can_access_room(Acc, From, To) ->
+    Can = case mod_muc_room:can_access_room(To, From) of
         {error, _} -> false;
         {ok, CanAccess} -> CanAccess
-    end.
+    end,
+    maps:put(can_access_room, Can, Acc).
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -541,8 +541,10 @@ route_by_type(<<"iq">>, {From, To, Packet}, #state{host = Host} = State) ->
     ServerHost = State#state.server_host,
     case jlib:iq_query_info(Packet) of
         #iq{type = get, xmlns = ?NS_DISCO_INFO = XMLNS, lang = Lang} = IQ ->
-            #{info := Info} = ejabberd_hooks:run_fold(disco_info, ServerHost, #{},
-                                           [ServerHost, ?MODULE, "", Lang]),
+            InfoResp = ejabberd_hooks:run_fold(disco_info, ServerHost,
+                                                      mongoose_perdix:new(),
+                                                      [ServerHost, ?MODULE, "", Lang]),
+            Info = mongoose_perdix:get(info, InfoResp, []),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = [{<<"xmlns">>, XMLNS}],

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -58,9 +58,9 @@
 -export([route/3]).
 
 %% Hook handlers
--export([prevent_service_unavailable/3,
+-export([prevent_service_unavailable/4,
          get_muc_service/5,
-         remove_user/2,
+         remove_user/3,
          add_rooms_to_roster/2,
          process_iq_get/5,
          process_iq_set/4,
@@ -255,11 +255,12 @@ process_packet(From, To, _InvalidReq, OrigPacket) ->
 %% Hook handlers
 %%====================================================================
 
--spec prevent_service_unavailable(From :: jid(), To :: jid(), Packet :: #xmlel{}) -> ok | stop.
-prevent_service_unavailable(_From, _To, Packet) ->
+-spec prevent_service_unavailable(Acc :: map(), From :: jid(), To :: jid(),
+                                  Packet :: #xmlel{}) -> map() | {stop, map()}.
+prevent_service_unavailable(Acc, _From, _To, Packet) ->
     case xml:get_tag_attr_s(<<"type">>, Packet) of
-        <<"groupchat">> -> stop;
-        _Type -> ok
+        <<"groupchat">> -> {stop, Acc};
+        _Type -> Acc
     end.
 
 -spec get_muc_service(Acc :: {result, [jlib:xmlel()]}, From :: ejabberd:jid(), To :: ejabberd:jid(),
@@ -277,8 +278,8 @@ get_muc_service({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, _
 get_muc_service(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
--spec remove_user(User :: binary(), Server :: binary()) -> ok.
-remove_user(User, Server) ->
+-spec remove_user(Acc :: map(), User :: binary(), Server :: binary()) -> ok.
+remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     UserUS = {LUser, LServer},
@@ -288,7 +289,8 @@ remove_user(User, Server) ->
             ?ERROR_MSG("hook=remove_user,error=~p", [Err]);
         AffectedRooms ->
             bcast_removed_user(UserUS, AffectedRooms, Version),
-            maybe_forget_rooms(AffectedRooms)
+            maybe_forget_rooms(AffectedRooms),
+            Acc
     end.
 
 -spec add_rooms_to_roster(Acc :: [#roster{}], UserUS :: ejabberd:simple_bare_jid()) -> [#roster{}].

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -265,7 +265,8 @@ prevent_service_unavailable(Acc, _From, _To, Packet) ->
 
 -spec get_muc_service(Acc :: map(), From :: ejabberd:jid(), To :: ejabberd:jid(),
                       NS :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]}.
-get_muc_service(#{local_items := Nodes} = Acc, _From, #jid{lserver = LServer} = _To, <<"">>, _Lang) ->
+get_muc_service(Acc, _From, #jid{lserver = LServer} = _To, <<"">>, _Lang) ->
+    Nodes = mongoose_perdix:get(local_items, Acc, []),
     XMLNS = case get_opt(LServer, legacy_mode, ?DEFAULT_LEGACY_MODE) of
                 true -> ?NS_MUC;
                 false -> ?NS_MUC_LIGHT
@@ -274,9 +275,9 @@ get_muc_service(#{local_items := Nodes} = Acc, _From, #jid{lserver = LServer} = 
     Item = [#xmlel{name = <<"item">>,
                    attrs = [{<<"jid">>, Host},
                             {<<"node">>, XMLNS}]}],
-    maps:put(local_items, [Item | Nodes], Acc);
-get_muc_service(Acc, _From, _To, _Node, _Lang) ->
-    Acc.
+    maps:put(local_items, [Item | Nodes], Acc).
+%%get_muc_service(Acc, _From, _To, _Node, _Lang) ->
+%%    Acc.
 
 -spec remove_user(Acc :: map(), User :: binary(), Server :: binary()) -> ok.
 remove_user(Acc, User, Server) ->

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -40,6 +40,7 @@
 -export([inspect_packet/4,
          pop_offline_messages/3,
          get_sm_features/5,
+         get_local_features/5,
          remove_expired_messages/1,
          remove_old_messages/2,
          remove_user/2,
@@ -133,7 +134,7 @@ start(Host, Opts) ->
     ejabberd_hooks:add(disco_sm_features, Host,
 		       ?MODULE, get_sm_features, 50),
     ejabberd_hooks:add(disco_local_features, Host,
-		       ?MODULE, get_sm_features, 50),
+		       ?MODULE, get_local_features, 50),
     ejabberd_hooks:add(amp_determine_strategy, Host,
                        ?MODULE, determine_amp_strategy, 30),
     ejabberd_hooks:add(failed_to_store_message, Host,
@@ -150,7 +151,7 @@ stop(Host) ->
     ejabberd_hooks:delete(anonymous_purge_hook, Host,
 			  ?MODULE, remove_user, 50),
     ejabberd_hooks:delete(disco_sm_features, Host, ?MODULE, get_sm_features, 50),
-    ejabberd_hooks:delete(disco_local_features, Host, ?MODULE, get_sm_features, 50),
+    ejabberd_hooks:delete(disco_local_features, Host, ?MODULE, get_local_features, 50),
     ejabberd_hooks:delete(amp_determine_strategy, Host,
                           ?MODULE, determine_amp_strategy, 30),
     ejabberd_hooks:delete(failed_to_store_message, Host,
@@ -334,18 +335,25 @@ code_change(_OldVsn, State, _Extra) ->
 %% Handlers
 %% ------------------------------------------------------------------
 
-get_sm_features(Acc, _From, _To, <<"">> = _Node, _Lang) ->
-    add_feature(Acc, ?NS_FEATURE_MSGOFFLINE);
-get_sm_features(_Acc, _From, _To, ?NS_FEATURE_MSGOFFLINE, _Lang) ->
+get_sm_features(Acc, From, To, Node, Lang) ->
+    get_features(sm_features, Acc, From, To, Node, Lang).
+
+get_local_features(Acc, From, To, Node, Lang) ->
+    get_features(features, Acc, From, To, Node, Lang).
+
+get_features(Key, Acc, _From, _To, <<"">> = _Node, _Lang) ->
+    add_feature(Key, Acc, ?NS_FEATURE_MSGOFFLINE);
+get_features(Key, Acc, _From, _To, ?NS_FEATURE_MSGOFFLINE, _Lang) ->
     %% override all lesser features...
-    {result, []};
-get_sm_features(Acc, _From, _To, _Node, _Lang) ->
+    maps:put(Key, [], Acc);
+get_features(_Key, Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
-add_feature({result, Features}, Feature) ->
-    {result, Features ++ [Feature]};
-add_feature(_, Feature) ->
-    {result, [Feature]}.
+add_feature(Key, Acc, Feature) ->
+    Features = maps:get(Key, Acc),
+    maps:put(Key, Features ++ [Feature], Acc).
+%%add_feature(_, Feature) ->
+%%    {result, [Feature]}.
 
 %% This function should be called only from hook
 %% Calling it directly is dangerous and my store unwanted message

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -345,13 +345,13 @@ get_features(Key, Acc, _From, _To, <<"">> = _Node, _Lang) ->
     add_feature(Key, Acc, ?NS_FEATURE_MSGOFFLINE);
 get_features(Key, Acc, _From, _To, ?NS_FEATURE_MSGOFFLINE, _Lang) ->
     %% override all lesser features...
-    maps:put(Key, [], Acc);
+    mongoose_perdix:put(Key, [], Acc);
 get_features(_Key, Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
 add_feature(Key, Acc, Feature) ->
-    Features = maps:get(Key, Acc),
-    maps:put(Key, Features ++ [Feature], Acc).
+    Features = mongoose_perdix:get(Key, Acc),
+    mongoose_perdix:put(Key, Features ++ [Feature], Acc).
 %%add_feature(_, Feature) ->
 %%    {result, [Feature]}.
 

--- a/apps/ejabberd/src/mod_offline_riak.erl
+++ b/apps/ejabberd/src/mod_offline_riak.erl
@@ -145,7 +145,7 @@ pop_msg(Key, LUser, LServer, To) ->
         MD = riakc_obj:get_update_metadata(Obj),
         [Timestamp] = riakc_obj:get_secondary_index(MD, ?TIMESTAMP_IDX),
         [Expire] = riakc_obj:get_secondary_index(MD, ?EXPIRE_IDX),
-        User = riakc_obj:get_secondary_index(MD, ?USER_IDX),
+%%        User = riakc_obj:get_secondary_index(MD, ?USER_IDX),
         From = riakc_obj:get_user_metadata_entry(MD, <<"from">>),
 
         mongoose_riak:delete(bucket_type(LServer), Key),

--- a/apps/ejabberd/src/mod_offline_stub.erl
+++ b/apps/ejabberd/src/mod_offline_stub.erl
@@ -30,7 +30,7 @@
          stop/1]).
 
 %% Hook handlers
--export([stop_hook_processing/3]).
+-export([stop_hook_processing/4]).
 
 -spec start(any(), any()) -> 'ok'.
 start(Host, _Opts) ->
@@ -48,6 +48,6 @@ stop(Host) ->
 handlers() ->
     [{offline_message_hook, ?MODULE, stop_hook_processing, 75}].
 
--spec stop_hook_processing(any(), any(), any()) -> stop.
-stop_hook_processing(_From, _To, _Packet) ->
-    stop.
+-spec stop_hook_processing(map(), any(), any(), any()) -> {stop, map()}.
+stop_hook_processing(Acc, _From, _To, _Packet) ->
+    {stop, Acc}.

--- a/apps/ejabberd/src/mod_ping.erl
+++ b/apps/ejabberd/src/mod_ping.erl
@@ -52,10 +52,10 @@
 
 %% Hook callbacks
 -export([iq_ping/3,
-         user_online/3,
-         user_offline/4,
-         user_send/3,
-         user_keep_alive/1]).
+         user_online/4,
+         user_offline/5,
+         user_send/4,
+         user_keep_alive/2]).
 
 -record(state, {host = <<"">>,
                 send_pings = ?DEFAULT_SEND_PINGS,
@@ -204,17 +204,21 @@ iq_ping(_From, _To, #iq{type = Type, sub_el = SubEl} = IQ) ->
             IQ#iq{type = error, sub_el = [SubEl, ?ERR_FEATURE_NOT_IMPLEMENTED]}
     end.
 
-user_online(_SID, JID, _Info) ->
-    start_ping(JID#jid.lserver, JID).
+user_online(Acc, _SID, JID, _Info) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_offline(_SID, JID, _Info, _Reason) ->
-    stop_ping(JID#jid.lserver, JID).
+user_offline(Acc, _SID, JID, _Info, _Reason) ->
+    stop_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_send(JID, _From, _Packet) ->
-    start_ping(JID#jid.lserver, JID).
+user_send(Acc, JID, _From, _Packet) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_keep_alive(JID) ->
-    start_ping(JID#jid.lserver, JID).
+user_keep_alive(Acc, JID) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -37,6 +37,7 @@
          get_user_list/3,
          check_packet/6,
          remove_user/2,
+         remove_user/3,
          updated_list/3]).
 
 -include("ejabberd.hrl").
@@ -122,7 +123,7 @@ start(Host, Opts) ->
                                                  remove_privacy_list, replace_privacy_list,
                                                  get_default_list]),
     ?BACKEND:init(Host, Opts),
-    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+%%    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     ejabberd_hooks:add(privacy_iq_get, Host,
                ?MODULE, process_iq_get, 50),
     ejabberd_hooks:add(privacy_iq_set, Host,
@@ -406,6 +407,12 @@ is_type_match(Type, Value, JID, Subscription, Groups) ->
             lists:member(Value, Groups)
     end.
 
+%% #rh
+remove_user(Acc, User, Server) ->
+    case remove_user(User, Server) of
+        ok -> Acc;
+        E -> E
+    end.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -32,6 +32,7 @@
 -export([start/2,
          stop/1,
          process_sm_iq/3,
+         remove_user/3,
          remove_user/2]).
 
 -include("ejabberd.hrl").
@@ -87,6 +88,14 @@ stop(Host) ->
 
 %% ------------------------------------------------------------------
 %% Handlers
+
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    case remove_user(User, Server) of
+        ok -> Acc;
+        E -> E
+    end.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -487,27 +487,28 @@ is_subscribed(Recipient, NodeOwner, NodeOptions) ->
 %%
 
 -spec disco_local_identity(
-        Acc    :: [xmlel()],
+        Acc    :: map(),
           _From  :: jid(),
           To     :: jid(),
           Node   :: <<>> | mod_pubsub:nodeId(),
           Lang   :: binary())
         -> [xmlel()].
-disco_local_identity(Acc, _From, To, <<>>, _Lang) ->
-    case lists:member(?PEPNODE, plugins(To#jid.lserver)) of
+disco_local_identity(#{local_identity := Ids} = Acc, _From, To, <<>>, _Lang) ->
+    NIds = case lists:member(?PEPNODE, plugins(To#jid.lserver)) of
         true ->
             [#xmlel{name = <<"identity">>,
                     attrs = [{<<"category">>, <<"pubsub">>},
                              {<<"type">>, <<"pep">>}]}
-             | Acc];
+             | Ids];
         false ->
-            Acc
-    end;
+            Ids
+    end,
+    maps:put(local_identity, NIds, Acc);
 disco_local_identity(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
 -spec disco_local_features(
-        Acc    :: [xmlel()],
+        Acc    :: map(),
           _From  :: jid(),
           To     :: jid(),
           Node   :: <<>> | mod_pubsub:nodeId(),
@@ -515,11 +516,13 @@ disco_local_identity(Acc, _From, _To, _Node, _Lang) ->
         -> [binary(),...].
 disco_local_features(Acc, _From, To, <<>>, _Lang) ->
     Host = To#jid.lserver,
-    Feats = case Acc of
-                {result, I} -> I;
-                _ -> []
-            end,
-    {result, Feats ++ [feature(F) || F <- features(Host, <<>>)]};
+    Feats = maps:get(features, Acc, []),
+%%    Feats = case Acc of
+%%                {result, I} -> I;
+%%                _ -> []
+%%            end,
+    NFeats = Feats ++ [feature(F) || F <- features(Host, <<>>)],
+    maps:put(features, NFeats, Acc);
 disco_local_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
@@ -527,17 +530,18 @@ disco_local_items(Acc, _From, _To, <<>>, _Lang) -> Acc;
 disco_local_items(Acc, _From, _To, _Node, _Lang) -> Acc.
 
 -spec disco_sm_identity(
-        Acc  :: empty | [xmlel()],
+        Acc  :: map(),
           From :: jid(),
           To   :: jid(),
           Node :: mod_pubsub:nodeId(),
           Lang :: binary())
         -> [xmlel()].
-disco_sm_identity(empty, From, To, Node, Lang) ->
-    disco_sm_identity([], From, To, Node, Lang);
-disco_sm_identity(Acc, From, To, Node, _Lang) ->
-    disco_identity(jid:to_lower(jid:to_bare(To)), Node, From)
-        ++ Acc.
+%%disco_sm_identity(empty, From, To, Node, Lang) ->
+%%    disco_sm_identity([], From, To, Node, Lang);
+disco_sm_identity(#{sm_identity := Ids} = Acc, From, To, Node, _Lang) ->
+    NIds = disco_identity(jid:to_lower(jid:to_bare(To)), Node, From)
+        ++ Ids,
+    maps:put(sm_identity, NIds, Acc).
 
 disco_identity(_Host, <<>>, _From) ->
     [#xmlel{name = <<"identity">>,
@@ -568,18 +572,18 @@ disco_identity(Host, Node, From) ->
     end.
 
 -spec disco_sm_features(
-        Acc  :: empty | {result, Features::[Feature::binary()]},
+        Acc  :: map(),
           From :: jid(),
           To   :: jid(),
           Node :: mod_pubsub:nodeId(),
           Lang :: binary())
         -> {result, Features::[Feature::binary()]}.
-disco_sm_features(empty, From, To, Node, Lang) ->
-    disco_sm_features({result, []}, From, To, Node, Lang);
-disco_sm_features({result, OtherFeatures} = _Acc, From, To, Node, _Lang) ->
-    {result,
-     OtherFeatures ++
-         disco_features(jid:to_lower(jid:to_bare(To)), Node, From)};
+%%disco_sm_features(empty, From, To, Node, Lang) ->
+%%    disco_sm_features({result, []}, From, To, Node, Lang);
+disco_sm_features(#{sm_features := OtherFeatures} = Acc, From, To, Node, _Lang) ->
+    NFeat = OtherFeatures ++
+        disco_features(jid:to_lower(jid:to_bare(To)), Node, From),
+    maps:put(sm_features, NFeat, Acc);
 disco_sm_features(Acc, _From, _To, _Node, _Lang) -> Acc.
 
 disco_features(Host, <<>>, _From) ->
@@ -934,8 +938,8 @@ do_route(ServerHost, Access, Plugins, Host, From, To, Packet) ->
                         #iq{type = get, xmlns = ?NS_DISCO_INFO, sub_el = SubEl, lang = Lang} = IQ ->
                             #xmlel{attrs = QAttrs} = SubEl,
                             Node = xml:get_attr_s(<<"node">>, QAttrs),
-                            Info = ejabberd_hooks:run_fold(disco_info, ServerHost,
-                                                           [],
+                            #{info := Info} = ejabberd_hooks:run_fold(disco_info, ServerHost,
+                                                           #{},
                                                            [ServerHost, ?MODULE, <<>>, <<>>]),
                             Res = case iq_disco_info(Host, Node, From, Lang) of
                                       {result, IQRes} ->

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -63,9 +63,9 @@
 -define(PEPNODE, <<"pep">>).
 
 %% exports for hooks
--export([presence_probe/3, caps_change/4,
-         in_subscription/6, out_subscription/4,
-         on_user_offline/4, remove_user/2,
+-export([presence_probe/4, caps_change/4, caps_change/5,
+         in_subscription/7, out_subscription/5,
+         on_user_offline/5, remove_user/2, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
          disco_local_items/5, disco_sm_identity/5,
          disco_sm_features/5, disco_sm_items/5]).
@@ -669,16 +669,23 @@ disco_items(Host, Node, From) ->
 %% presence hooks handling functions
 %%
 
+%% #rh
+caps_change(Acc, FromJID, ToJID, Pid, Features) ->
+    caps_change(FromJID, ToJID, Pid, Features),
+    Acc.
+
 caps_change(#jid{luser = _U, lserver = S, lresource = _R} = FromJID, ToJID, Pid, _Features) ->
     case jid:to_lower(FromJID) == jid:to_lower(ToJID) of
         true -> notify_send_loop(S, {send_last_pep_items, ToJID, Pid});
         false -> ok
     end.
 
-presence_probe(#jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
-    notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID});
-presence_probe(_Host, _JID, _Pid) ->
-    ok.
+%% #rh
+presence_probe(Acc, #jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
+    notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID}),
+    Acc;
+presence_probe(Acc, _Host, _JID, _Pid) ->
+    Acc.
 
 notify_send_loop(ServerHost, Action) ->
     {SendLoop, _} = case whereis(gen_mod:get_module_proc(ServerHost, ?LOOPNAME)) of
@@ -691,7 +698,7 @@ notify_send_loop(ServerHost, Action) ->
 %% subscription hooks handling functions
 %%
 
-out_subscription(User, Server, JID, subscribed) ->
+out_subscription(Acc, User, Server, JID, subscribed) ->
     Owner = jid:make(User, Server, <<>>),
     {PUser, PServer, PResource} = jid:to_lower(JID),
     PResources = case PResource of
@@ -699,15 +706,15 @@ out_subscription(User, Server, JID, subscribed) ->
                      _ -> [PResource]
                  end,
     notify_send_loop(Server, {send_last_items_from_owner, Owner, {PUser, PServer, PResources}}),
-    true;
-out_subscription(_, _, _, _) ->
-    true.
+    Acc;
+out_subscription(Acc, _, _, _, _) ->
+    Acc.
 
-in_subscription(_, User, Server, Owner, unsubscribed, _) ->
+in_subscription(Acc, _, User, Server, Owner, unsubscribed, _) ->
     unsubscribe_user(jid:make(User, Server, <<>>), Owner),
-    true;
-in_subscription(_, _, _, _, _, _) ->
-    true.
+    Acc;
+in_subscription(Acc, _, _, _, _, _, _) ->
+    Acc.
 
 unsubscribe_user(Entity, Owner) ->
     spawn(fun () ->
@@ -750,6 +757,11 @@ unsubscribe_user(Host, Entity, Owner) ->
 %% -------
 %% user remove hook handling function
 %%
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),
@@ -3892,10 +3904,10 @@ tree(Host) ->
 
 tree(_Host, <<"virtual">>) ->
     nodetree_virtual;   % special case, virtual does not use any backend
-tree(Host, Name) ->
+tree(_Host, Name) ->
     binary_to_atom(<<"nodetree_", Name/binary>>, utf8).
 
-plugin(Host, Name) ->
+plugin(_Host, Name) ->
     binary_to_atom(<<"node_", Name/binary>>, utf8).
 
 plugins(Host) ->
@@ -3905,7 +3917,7 @@ plugins(Host) ->
         Plugins -> Plugins
     end.
 
-subscription_plugin(Host) ->
+subscription_plugin(_Host) ->
     pubsub_subscription.
 
 config(ServerHost, Key) ->
@@ -4155,12 +4167,13 @@ extended_headers(Jids) ->
             attrs = [{<<"type">>, <<"replyto">>}, {<<"jid">>, Jid}]}
      || Jid <- Jids].
 
-on_user_offline(_, JID, _, _) ->
+on_user_offline(Acc, _, JID, _, _) ->
     {User, Server, Resource} = jid:to_lower(JID),
     case user_resources(User, Server) of
         [] -> purge_offline({User, Server, Resource});
         _ -> true
-    end.
+    end,
+    Acc.
 
 purge_offline(LJID) ->
     Host = host(element(2, LJID)),

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -493,7 +493,8 @@ is_subscribed(Recipient, NodeOwner, NodeOptions) ->
           Node   :: <<>> | mod_pubsub:nodeId(),
           Lang   :: binary())
         -> [xmlel()].
-disco_local_identity(#{local_identity := Ids} = Acc, _From, To, <<>>, _Lang) ->
+disco_local_identity(Acc, _From, To, <<>>, _Lang) ->
+    Ids = mongoose_perdix:get(local_identity, Acc, []),
     NIds = case lists:member(?PEPNODE, plugins(To#jid.lserver)) of
         true ->
             [#xmlel{name = <<"identity">>,
@@ -516,13 +517,13 @@ disco_local_identity(Acc, _From, _To, _Node, _Lang) ->
         -> [binary(),...].
 disco_local_features(Acc, _From, To, <<>>, _Lang) ->
     Host = To#jid.lserver,
-    Feats = maps:get(features, Acc, []),
+    Feats = mongoose_perdix:get(features, Acc, []),
 %%    Feats = case Acc of
 %%                {result, I} -> I;
 %%                _ -> []
 %%            end,
     NFeats = Feats ++ [feature(F) || F <- features(Host, <<>>)],
-    maps:put(features, NFeats, Acc);
+    mongoose_perdix:put(features, NFeats, Acc);
 disco_local_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
@@ -538,10 +539,11 @@ disco_local_items(Acc, _From, _To, _Node, _Lang) -> Acc.
         -> [xmlel()].
 %%disco_sm_identity(empty, From, To, Node, Lang) ->
 %%    disco_sm_identity([], From, To, Node, Lang);
-disco_sm_identity(#{sm_identity := Ids} = Acc, From, To, Node, _Lang) ->
+disco_sm_identity(Acc, From, To, Node, _Lang) ->
+    Ids = mongoose_perdix:get(sm_identity, Acc, []),
     NIds = disco_identity(jid:to_lower(jid:to_bare(To)), Node, From)
         ++ Ids,
-    maps:put(sm_identity, NIds, Acc).
+    mongoose_perdix:put(sm_identity, NIds, Acc).
 
 disco_identity(_Host, <<>>, _From) ->
     [#xmlel{name = <<"identity">>,
@@ -581,10 +583,11 @@ disco_identity(Host, Node, From) ->
 %%disco_sm_features(empty, From, To, Node, Lang) ->
 %%    disco_sm_features({result, []}, From, To, Node, Lang);
 disco_sm_features(#{sm_features := OtherFeatures} = Acc, From, To, Node, _Lang) ->
+    OtherFeatures = mongoose_perdix:get(sm_features, Acc, []),
     NFeat = OtherFeatures ++
         disco_features(jid:to_lower(jid:to_bare(To)), Node, From),
-    maps:put(sm_features, NFeat, Acc);
-disco_sm_features(Acc, _From, _To, _Node, _Lang) -> Acc.
+    mongoose_perdix:put(sm_features, NFeat, Acc).
+%%disco_sm_features(Acc, _From, _To, _Node, _Lang) -> Acc.
 
 disco_features(Host, <<>>, _From) ->
     [?NS_PUBSUB | [feature(F) || F <- plugin_features(Host, <<"pep">>)]];
@@ -612,12 +615,14 @@ disco_features(Host, Node, From) ->
                                                 %    when is_binary(Node) ->
                                                 %    disco_sm_items(Acc, From, To, iolist_to_binary(Node),
                                                 %                   Lang);
-disco_sm_items(empty, From, To, Node, Lang) ->
-    disco_sm_items({result, []}, From, To, Node, Lang);
-disco_sm_items({result, OtherItems}, From, To, Node, _Lang) ->
-    {result, lists:usort(OtherItems ++
-                             disco_items(jid:to_lower(jid:to_bare(To)), Node, From))};
-disco_sm_items(Acc, _From, _To, _Node, _Lang) -> Acc.
+%%disco_sm_items(empty, From, To, Node, Lang) ->
+%%    disco_sm_items({result, []}, From, To, Node, Lang);
+disco_sm_items(Acc, From, To, Node, _Lang) ->
+%%    {result, lists:usort(OtherItems ++ disco_items(jid:to_lower(jid:to_bare(To)), Node, From))};
+    OtherItems = mongoose_perdix:get(sm_items, Acc, []),
+    NItems = lists:usort(OtherItems ++ disco_items(jid:to_lower(jid:to_bare(To)), Node, From)),
+    mongoose_perdix:put(sm_items, NItems, Acc).
+%%disco_sm_items(Acc, _From, _To, _Node, _Lang) -> Acc.
 
 -spec disco_items(
         Host :: mod_pubsub:host(),
@@ -938,9 +943,10 @@ do_route(ServerHost, Access, Plugins, Host, From, To, Packet) ->
                         #iq{type = get, xmlns = ?NS_DISCO_INFO, sub_el = SubEl, lang = Lang} = IQ ->
                             #xmlel{attrs = QAttrs} = SubEl,
                             Node = xml:get_attr_s(<<"node">>, QAttrs),
-                            #{info := Info} = ejabberd_hooks:run_fold(disco_info, ServerHost,
-                                                           #{},
+                            InfoResp = ejabberd_hooks:run_fold(disco_info, ServerHost,
+                                                           mongoose_perdix:new(),
                                                            [ServerHost, ?MODULE, <<>>, <<>>]),
+                            Info = mongoose_perdix:get(info, InfoResp, []),
                             Res = case iq_disco_info(Host, Node, From, Lang) of
                                       {result, IQRes} ->
                                           jlib:iq_to_xml(IQ#iq{type = result,

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -48,9 +48,11 @@
          get_subscription_lists/3,
          get_roster/2,
          in_subscription/6,
-         out_subscription/4,
+         in_subscription/7,
+         out_subscription/5,
          set_items/3,
          remove_user/2,
+         remove_user/3,
          get_jid_info/4,
          item_to_xml/1,
          get_versioning_feature/2,
@@ -568,12 +570,19 @@ roster_subscribe_t(LUser, LServer, LJID, Item) ->
 transaction(LServer, F) ->
     ?BACKEND:transaction(LServer, F).
 
+in_subscription(Acc, _, User, Server, JID, Type, Reason) ->
+    process_subscription(in, User, Server, JID, Type,
+        Reason),
+    Acc.
+
+out_subscription(Acc, User, Server, JID, Type) ->
+    process_subscription(out, User, Server, JID, Type, <<"">>),
+    Acc.
+
+%% temporary - for folds
 in_subscription(_, User, Server, JID, Type, Reason) ->
     process_subscription(in, User, Server, JID, Type,
                          Reason).
-
-out_subscription(User, Server, JID, Type) ->
-    process_subscription(out, User, Server, JID, Type, <<"">>).
 
 get_roster_by_jid_with_groups_t(LUser, LServer, LJID) ->
     ?BACKEND:get_roster_by_jid_with_groups_t(LUser, LServer, LJID).
@@ -754,6 +763,11 @@ in_auto_reply(from, none, unsubscribe) -> unsubscribed;
 in_auto_reply(from, out, unsubscribe) -> unsubscribed;
 in_auto_reply(both, none, unsubscribe) -> unsubscribed;
 in_auto_reply(_, _, _) -> none.
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -39,8 +39,8 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -export([get_user_roster/2, get_subscription_lists/3,
-         get_jid_info/4, process_item/2, in_subscription/6,
-         out_subscription/4]).
+         get_jid_info/4, process_item/2, in_subscription/7,
+         out_subscription/5]).
 
 -export([config_change/4]).
 
@@ -179,13 +179,25 @@ get_jid_info({Subscription, Groups}, User, Server, JID) ->
         error -> {Subscription, Groups}
     end.
 
-in_subscription(Acc, User, Server, JID, Type, _Reason) ->
-    process_subscription(in, User, Server, JID, Type, Acc).
+in_subscription(Acc, _, User, Server, JID, Type, _Reason) ->
+    case process_subscription(in, User, Server, JID, Type) of
+        stop ->
+            {stop, Acc};
+        {stop, false} ->
+            {stop, acc};
+        _ -> Acc
+    end.
 
-out_subscription(User, Server, JID, Type) ->
-    process_subscription(out, User, Server, JID, Type, false).
+out_subscription(Acc, User, Server, JID, Type) ->
+    case process_subscription(out, User, Server, JID, Type) of
+        stop ->
+            {stop, Acc};
+        {stop, false} ->
+            {stop, acc};
+        _ -> Acc
+    end.
 
-process_subscription(Direction, User, Server, JID, _Type, Acc) ->
+process_subscription(Direction, User, Server, JID, _Type) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     US = {LUser, LServer},
@@ -203,7 +215,7 @@ process_subscription(Direction, User, Server, JID, _Type, Acc) ->
                 in -> {stop, false};
                 out -> stop
             end;
-        false -> Acc
+        false -> false
     end.
 
 %%====================================================================

--- a/apps/ejabberd/src/mod_stream_management.erl
+++ b/apps/ejabberd/src/mod_stream_management.erl
@@ -52,8 +52,9 @@ stop(Host) ->
 %% `ejabberd_hooks' handlers
 %%
 
-add_sm_feature(Acc, _Server) ->
-    lists:keystore(<<"sm">>, #xmlel.name, Acc, sm()).
+add_sm_feature(#{features := Feat} = Acc, _Server) ->
+    NFeat = lists:keystore(<<"sm">>, #xmlel.name, Feat, sm()),
+    maps:put(features, NFeat, Acc).
 
 sm() ->
     #xmlel{name = <<"sm">>,

--- a/apps/ejabberd/src/mod_stream_management.erl
+++ b/apps/ejabberd/src/mod_stream_management.erl
@@ -8,8 +8,8 @@
 
 %% `ejabberd_hooks' handlers
 -export([add_sm_feature/2,
-         remove_smid/4,
-         session_cleanup/4]).
+         remove_smid/5,
+         session_cleanup/5]).
 
 %% `ejabberd.cfg' options (don't use outside of tests)
 -export([get_buffer_max/1,
@@ -59,18 +59,19 @@ sm() ->
     #xmlel{name = <<"sm">>,
            attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]}.
 
-remove_smid(SID, _JID, _Info, _Reason) ->
+remove_smid(Acc, SID, _JID, _Info, _Reason) ->
     case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
         [] ->
             ok;
         [#sm_session{} = SMSession] ->
             mnesia:sync_dirty(fun mnesia:delete_object/1, [SMSession])
-    end.
+    end,
+    Acc.
 
--spec session_cleanup(LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
+-spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(_LUser, _LServer, _LResource, SID) ->
-    remove_smid(SID, undefined, undefined, undefined).
+session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
+    remove_smid(Acc, SID, undefined, undefined, undefined).
 
 %%
 %% `ejabberd.cfg' options (don't use outside of tests)

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -315,18 +315,20 @@ set_vcard({error, _} = E, _From, _VCARD) -> E.
 
 get_local_features({error, _Error}=Acc, _From, _To, _Node, _Lang) ->
     Acc;
-get_local_features(Acc, _From, _To, Node, _Lang) ->
-    case Node of
+get_local_features(#{features := Feat} = Acc, _From, _To, Node, _Lang) ->
+    NFeat = case Node of
         <<>> ->
-            case Acc of
-                {result, Features} ->
-                    {result, [?NS_VCARD | Features]};
-                empty ->
-                    {result, [?NS_VCARD]}
-            end;
+            [?NS_VCARD | Feat];
+%%            case Acc of
+%%                {result, Features} ->
+%%                    {result, [?NS_VCARD | Features]};
+%%                empty ->
+%%                    {result, [?NS_VCARD]}
+%%            end;
         _ ->
-            Acc
-    end.
+            Feat
+    end,
+    maps:put(features, NFeat, Acc).
 
 %% #rh
 remove_user(Acc, User, Server) ->
@@ -406,7 +408,7 @@ do_route(_VHost, From, To, Packet, #iq{type = set,
 do_route(VHost, From, To, _Packet, #iq{type = get,
                                        xmlns = ?NS_DISCO_INFO,
                                        lang = Lang} = IQ) ->
-    Info = ejabberd_hooks:run_fold(disco_info, VHost, [], [VHost, ?MODULE, "", ""]),
+    #{info := Info} = ejabberd_hooks:run_fold(disco_info, VHost, #{}, [VHost, ?MODULE, "", ""]),
     ResIQ = IQ#iq{type = result,
                   sub_el = [#xmlel{name = <<"query">>,
                                    attrs =[{<<"xmlns">>,?NS_DISCO_INFO}],

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -58,6 +58,7 @@
          process_sm_iq/3,
          get_local_features/5,
          remove_user/2,
+         remove_user/3,
          set_vcard/3]).
 
 -export([start_link/2]).
@@ -236,7 +237,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 process_local_iq(_From,_To,#iq{type = set, sub_el = SubEl} = IQ) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
-process_local_iq(_From,_To,#iq{type = get, lang = Lang} = IQ) ->
+process_local_iq(_From,_To,#iq{type = get} = IQ) ->
     IQ#iq{type = result,
           sub_el = [#xmlel{name = <<"vCard">>, attrs = [{<<"xmlns">>, ?NS_VCARD}],
                            children = [#xmlel{name = <<"FN">>,
@@ -326,6 +327,11 @@ get_local_features(Acc, _From, _To, Node, _Lang) ->
         _ ->
             Acc
     end.
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -315,10 +315,11 @@ set_vcard({error, _} = E, _From, _VCARD) -> E.
 
 get_local_features({error, _Error}=Acc, _From, _To, _Node, _Lang) ->
     Acc;
-get_local_features(#{features := Feat} = Acc, _From, _To, Node, _Lang) ->
+get_local_features(Acc, _From, _To, Node, _Lang) ->
+%%    Feat = mongoose_perdix:get(features, Acc, []),
     NFeat = case Node of
         <<>> ->
-            [?NS_VCARD | Feat];
+            ?NS_VCARD;
 %%            case Acc of
 %%                {result, Features} ->
 %%                    {result, [?NS_VCARD | Features]};
@@ -326,9 +327,9 @@ get_local_features(#{features := Feat} = Acc, _From, _To, Node, _Lang) ->
 %%                    {result, [?NS_VCARD]}
 %%            end;
         _ ->
-            Feat
+            []
     end,
-    maps:put(features, NFeat, Acc).
+    mongoose_perdix:append(features, NFeat, Acc).
 
 %% #rh
 remove_user(Acc, User, Server) ->

--- a/apps/ejabberd/src/mongoose_cleaner.erl
+++ b/apps/ejabberd/src/mongoose_cleaner.erl
@@ -74,12 +74,12 @@ cleanup_modules(Node) ->
             ?DEBUG("could not get ~p~n" , [?NODE_CLEANUP_LOCK(Node)]),
             {ok, aborted};
         Result ->
-            ?WARNING_MSG("cleanup result: ~p~n", [Result]),
+            ?WARNING_MSG("cleanup result: ~p~n", [maps:get(cleanup_result, Result, none)]),
             {ok, Result}
     end.
 
 run_node_cleanup(Node) ->
     {Elapsed, RetVal} = timer:tc(ejabberd_hooks, run, [node_cleanup, [Node]]),
     ?WARNING_MSG("cleanup took=~pms, result: ~p~n",
-                 [erlang:round(Elapsed / 1000), RetVal]),
+                 [erlang:round(Elapsed / 1000), maps:get(cleanup_result, RetVal, none)]),
     RetVal.

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -372,6 +372,7 @@ check_and_execute(Caller, Command, Args) when is_map(Args) ->
     check_and_execute(Caller, Command, ArgList);
 check_and_execute(Caller, Command, Args) ->
     % check permissions
+    Av = is_available_for(Caller, Command),
     case is_available_for(Caller, Command) of
         true ->
             ok;

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -372,7 +372,6 @@ check_and_execute(Caller, Command, Args) when is_map(Args) ->
     check_and_execute(Caller, Command, ArgList);
 check_and_execute(Caller, Command, Args) ->
     % check permissions
-    Av = is_available_for(Caller, Command),
     case is_available_for(Caller, Command) of
         true ->
             ok;

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -16,44 +16,44 @@
 %%-------------------
 %% Internal exports
 %%-------------------
--export([sm_register_connection_hook/3,
-         sm_remove_connection_hook/4,
-         auth_failed/2,
-         user_send_packet/3,
-         user_receive_packet/4,
-         xmpp_bounce_message/2,
-         xmpp_stanza_dropped/3,
-         xmpp_send_element/2,
+-export([sm_register_connection_hook/4,
+         sm_remove_connection_hook/5,
+         auth_failed/3,
+         user_send_packet/4,
+         user_receive_packet/5,
+         xmpp_bounce_message/3,
+         xmpp_stanza_dropped/4,
+         xmpp_send_element/3,
          roster_get/2,
-         roster_set/3,
-         roster_push/2,
+         roster_set/4,
+         roster_push/3,
          roster_in_subscription/6,
-         register_user/2,
-         remove_user/2,
+         register_user/3,
+         remove_user/3,
          privacy_iq_get/5,
          privacy_iq_set/4,
          privacy_check_packet/6,
-         user_ping_timeout/1,
-         privacy_list_push/4,
+         user_ping_timeout/2,
+         privacy_list_push/5,
          mam_get_prefs/4,
          mam_set_prefs/7,
-         mam_remove_archive/3,
+         mam_remove_archive/4,
          mam_lookup_messages/14,
          mam_archive_message/9,
-         mam_flush_messages/2,
-         mam_drop_message/1,
-         mam_drop_iq/5,
-         mam_drop_messages/2,
+         mam_flush_messages/3,
+         mam_drop_message/2,
+         mam_drop_iq/6,
+         mam_drop_messages/3,
          mam_purge_single_message/6,
          mam_purge_multiple_messages/9,
          mam_muc_get_prefs/4,
          mam_muc_set_prefs/7,
-         mam_muc_remove_archive/3,
+         mam_muc_remove_archive/4,
          mam_muc_lookup_messages/14,
          mam_muc_archive_message/9,
-         mam_muc_flush_messages/2,
+         mam_muc_flush_messages/3,
          mam_muc_drop_message/1,
-         mam_muc_drop_iq/5,
+         mam_muc_drop_iq/6,
          mam_muc_drop_messages/2,
          mam_muc_purge_single_message/6,
          mam_muc_purge_multiple_messages/9
@@ -61,7 +61,7 @@
 
 -type hook() :: [atom() | ejabberd:server() | integer(),...].
 -type metrics_notify_return() ::
-                'ok'
+                map()
                 | {'error',_,'nonexistent_metric' | 'unsupported_metric_type'}.
 
 %%-------------------
@@ -110,28 +110,32 @@ get_hooks(Host) ->
      [mam_muc_purge_multiple_message, Host, ?MODULE, mam_muc_purge_multiple_message, 50]].
 
 
--spec sm_register_connection_hook(tuple(), ejabberd:jid(), term()
+-spec sm_register_connection_hook(map(), tuple(), ejabberd:jid(), term()
                                  ) -> metrics_notify_return().
-sm_register_connection_hook(_,#jid{server = Server}, _) ->
+sm_register_connection_hook(Acc, _,#jid{server = Server}, _) ->
     mongoose_metrics:update(Server, sessionSuccessfulLogins, 1),
-    mongoose_metrics:update(Server, sessionCount, 1).
+    mongoose_metrics:update(Server, sessionCount, 1),
+    Acc.
 
--spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
+-spec sm_remove_connection_hook(map(), tuple(), ejabberd:jid(),
                                 term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
-sm_remove_connection_hook(_,#jid{server = Server},_, _Reason) ->
+sm_remove_connection_hook(Acc, _,#jid{server = Server},_, _Reason) ->
     mongoose_metrics:update(Server, sessionLogouts, 1),
-    mongoose_metrics:update(Server, sessionCount, -1).
+    mongoose_metrics:update(Server, sessionCount, -1),
+    Acc.
 
--spec auth_failed(binary(), binary()) -> metrics_notify_return().
-auth_failed(_,Server) ->
-    mongoose_metrics:update(Server, sessionAuthFails, 1).
+-spec auth_failed(map(), binary(), binary()) -> metrics_notify_return().
+auth_failed(Acc, _,Server) ->
+    mongoose_metrics:update(Server, sessionAuthFails, 1),
+    Acc.
 
--spec user_send_packet(ejabberd:jid(), tuple(), tuple()
+-spec user_send_packet(map(), ejabberd:jid(), tuple(), tuple()
                       ) -> metrics_notify_return().
-user_send_packet(#jid{server = Server},_,Packet) ->
+user_send_packet(Acc, #jid{server = Server},_,Packet) ->
     mongoose_metrics:update(Server, xmppStanzaSent, 1),
-    user_send_packet_type(Server, Packet).
+    user_send_packet_type(Server, Packet),
+    Acc.
 
 -spec user_send_packet_type(Server :: ejabberd:server(),
                             Packet :: jlib:xmlel()) -> metrics_notify_return().
@@ -142,10 +146,11 @@ user_send_packet_type(Server, #xmlel{name = <<"iq">>}) ->
 user_send_packet_type(Server, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(Server, xmppPresenceSent, 1).
 
--spec user_receive_packet(ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
-user_receive_packet(#jid{server = Server} ,_,_,Packet) ->
+-spec user_receive_packet(map(), ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
+user_receive_packet(Acc, #jid{server = Server} ,_,_,Packet) ->
     mongoose_metrics:update(Server, xmppStanzaReceived, 1),
-    user_receive_packet_type(Server, Packet).
+    user_receive_packet_type(Server, Packet),
+    Acc.
 
 -spec user_receive_packet_type(Server :: ejabberd:server(),
                                Packet :: jlib:xmlel()) -> metrics_notify_return().
@@ -156,18 +161,24 @@ user_receive_packet_type(Server, #xmlel{name = <<"iq">>}) ->
 user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(Server, xmppPresenceReceived, 1).
 
--spec xmpp_bounce_message(Server :: ejabberd:server(),
+-spec xmpp_bounce_message(Acc :: map(), Server :: ejabberd:server(),
                           tuple()) -> metrics_notify_return().
-xmpp_bounce_message(Server, _) ->
-    mongoose_metrics:update(Server, xmppMessageBounced, 1).
+xmpp_bounce_message(Acc, Server, _) ->
+    case mongoose_metrics:update(Server, xmppMessageBounced, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec xmpp_stanza_dropped(ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-xmpp_stanza_dropped(#jid{server = Server} ,_,_) ->
-   mongoose_metrics:update(Server, xmppStanzaDropped, 1).
+-spec xmpp_stanza_dropped(map(), ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
+xmpp_stanza_dropped(Acc, #jid{server = Server} ,_,_) ->
+   case mongoose_metrics:update(Server, xmppStanzaDropped, 1) of
+       ok -> Acc;
+       E -> E
+   end.
 
--spec xmpp_send_element(Server :: ejabberd:server(),
+-spec xmpp_send_element(Acc :: map(), Server :: ejabberd:server(),
                         Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
-xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
+xmpp_send_element(Acc, Server, #xmlel{name = Name, attrs = Attrs}) ->
     mongoose_metrics:update(Server, xmppStanzaCount, 1),
     case lists:keyfind(<<"type">>, 1, Attrs) of
         {<<"type">>, <<"error">>} ->
@@ -181,9 +192,10 @@ xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
                     mongoose_metrics:update(Server, xmppErrorPresence, 1)
             end;
         _ -> ok
-    end;
-xmpp_send_element(_, _) ->
-    ok.
+    end,
+    Acc;
+xmpp_send_element(Acc, _, _) ->
+    Acc.
 
 
 %% Roster
@@ -193,9 +205,13 @@ roster_get(Acc, {_, Server}) ->
     mongoose_metrics:update(Server, modRosterGets, 1),
     Acc.
 
--spec roster_set(JID :: ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-roster_set(#jid{server = Server},_,_) ->
-    mongoose_metrics:update(Server, modRosterSets, 1).
+-spec roster_set(Acc :: map(), JID :: ejabberd:jid(), tuple(), tuple()) ->
+    metrics_notify_return().
+roster_set(Acc, #jid{server = Server},_,_) ->
+    case mongoose_metrics:update(Server, modRosterSets, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
 roster_in_subscription(Acc,_,Server,_,subscribed,_) ->
@@ -207,19 +223,27 @@ roster_in_subscription(Acc,_,Server,_,unsubscribed,_) ->
 roster_in_subscription(Acc,_,_,_,_,_) ->
     Acc.
 
--spec roster_push(ejabberd:jid(),term()) -> metrics_notify_return().
-roster_push(#jid{server = Server},_) ->
-    mongoose_metrics:update(Server, modRosterPush, 1).
+-spec roster_push(map(), ejabberd:jid(), term()) -> metrics_notify_return().
+roster_push(Acc, #jid{server = Server},_) ->
+    case mongoose_metrics:update(Server, modRosterPush, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 %% Register
 
--spec register_user(binary(), ejabberd:server()) -> metrics_notify_return().
-register_user(_,Server) ->
-    mongoose_metrics:update(Server, modRegisterCount, 1).
+%% #rh
+-spec register_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
+register_user(Acc, _,Server) ->
+    case mongoose_metrics:update(Server, modRegisterCount, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec remove_user(binary(), ejabberd:server()) -> metrics_notify_return().
-remove_user(_,Server) ->
-    mongoose_metrics:update(Server, modUnregisterCount, 1).
+-spec remove_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
+remove_user(Acc, _,Server) ->
+    mongoose_metrics:update(Server, modUnregisterCount, 1),
+    Acc.
 
 %% Privacy
 
@@ -245,15 +269,19 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
     mongoose_metrics:update(Server, modPrivacySets, 1),
     Acc.
 
--spec privacy_list_push(_From :: ejabberd:jid(),
+-spec privacy_list_push(Acc :: map(),
+                        _From :: ejabberd:jid(),
                         To :: ejabberd:jid(),
                         Broadcast :: ejabberd_c2s:broadcast(),
                         SessionCount :: non_neg_integer()) -> ok | metrics_notify_return().
-privacy_list_push(_From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
-    mongoose_metrics:update(Server, modPrivacyPush, SessionCount).
+privacy_list_push(Acc, _From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
+    case mongoose_metrics:update(Server, modPrivacyPush, SessionCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
-user_ping_timeout(_JID) ->
-    ok.
+user_ping_timeout(Acc, _JID) ->
+    Acc.
 
 -spec privacy_check_packet(Acc :: allow | deny | block,
                           binary(),
@@ -290,11 +318,13 @@ mam_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJI
     mongoose_metrics:update(Host, modMamPrefsSets, 1),
     Result.
 
--spec mam_remove_archive(Host :: ejabberd:server(),
+-spec mam_remove_archive(Acc :: map(),
+                         Host :: ejabberd:server(),
                          _ArcID :: mod_mam:archive_id(),
                          _ArcJID :: ejabberd:jid()) -> metrics_notify_return().
-mam_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update(Host, modMamArchiveRemoved, 1).
+mam_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMamArchiveRemoved, 1),
+    Acc.
 
 mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
@@ -326,24 +356,41 @@ mam_archive_message(Result, Host,
     mongoose_metrics:update(Host, modMamArchived, 1),
     Result.
 
--spec mam_flush_messages(Host :: ejabberd:server(),
+-spec mam_flush_messages(Acc :: map(),
+                         Host :: ejabberd:server(),
                          MessageCount :: integer()) -> metrics_notify_return().
-mam_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update(Host, modMamFlushed, MessageCount).
+mam_flush_messages(Acc, Host, MessageCount) ->
+    case mongoose_metrics:update(Host, modMamFlushed, MessageCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_message(Host :: ejabberd:server()) -> metrics_notify_return().
-mam_drop_message(Host) ->
-    mongoose_metrics:update(Host, modMamDropped, 1).
+%% #rh
+-spec mam_drop_message(Acc :: map(), Host :: ejabberd:server()) -> metrics_notify_return().
+mam_drop_message(Acc, Host) ->
+    case mongoose_metrics:update(Host, modMamDropped, 1)of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_iq(Host :: ejabberd:server(), _To :: ejabberd:jid(),
+%% #rh
+-spec mam_drop_iq(Acc :: map(), Host :: ejabberd:server(), _To :: ejabberd:jid(),
     _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
-mam_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMamDroppedIQ, 1).
+mam_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    case mongoose_metrics:update(Host, modMamDroppedIQ, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_messages(Host :: ejabberd:server(),
+%% #rh
+-spec mam_drop_messages(Acc :: map(),
+                        Host :: ejabberd:server(),
                         Count :: integer()) -> metrics_notify_return().
-mam_drop_messages(Host, Count) ->
-    mongoose_metrics:update(Host, modMamDropped2, Count).
+mam_drop_messages(Acc, Host, Count) ->
+    case mongoose_metrics:update(Host, modMamDropped2, Count) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
     mongoose_metrics:update(Host, modMamSinglePurges, 1),
@@ -366,8 +413,11 @@ mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _Nev
     mongoose_metrics:update(Host, modMucMamPrefsSets, 1),
     Result.
 
-mam_muc_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1).
+mam_muc_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    case mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
@@ -390,14 +440,22 @@ mam_muc_archive_message(Result, Host,
     mongoose_metrics:update(Host, modMucMamArchived, 1),
     Result.
 
-mam_muc_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update(Host, modMucMamFlushed, MessageCount).
+%% #rh
+mam_muc_flush_messages(Acc, Host, MessageCount) ->
+    case mongoose_metrics:update(Host, modMucMamFlushed, MessageCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_drop_message(Host) ->
     mongoose_metrics:update(Host, modMucMamDropped, 1).
 
-mam_muc_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1).
+%% #rh
+mam_muc_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    case mongoose_metrics:update(Host, modMucMamDroppedIQ, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_drop_messages(Host, Count) ->
     mongoose_metrics:update(Host, modMucMamDropped2, Count).

--- a/apps/ejabberd/src/mongoose_perdix.erl
+++ b/apps/ejabberd/src/mongoose_perdix.erl
@@ -1,0 +1,44 @@
+%%%-------------------------------------------------------------------
+%%%
+%%% perdix is latin for partridge
+%%%
+%%% This module encapsulates a data type which will initially be passed to
+%%% hookhandlers as accumulator, and later might become a full-blown partridge
+%%% flying through the system.
+%%% Credits for the name go to Paweł Chrząszcz.
+
+%%%-------------------------------------------------------------------
+-module(mongoose_perdix).
+-author("bartek").
+
+%% API
+-export([new/0, new/1, put/3, get/2, get/3, append/3, to_map/1]).
+
+
+new() ->
+    #{}.
+
+new(A) when is_map(A) ->
+    A.
+
+%% @doc convert to map so that we can pattern-match on it
+to_map(P) ->
+    P.
+
+put(Key, Val, P) ->
+    maps:put(Key, Val, P).
+
+get(Key, Val) ->
+    maps:get(Key, Val).
+
+get(Key, Val, Default) ->
+    maps:get(Key, Val, Default).
+
+append(Key, Val, P) ->
+    L = get(Key, P, []),
+    maps:put(Key, append(Val, L), P).
+
+append(Val, L) when is_list(L), is_list(Val) ->
+    L ++ Val;
+append(Val, L) when is_list(L) ->
+    [Val | L].

--- a/apps/ejabberd/src/mongoose_perdix.erl
+++ b/apps/ejabberd/src/mongoose_perdix.erl
@@ -28,11 +28,11 @@ to_map(P) ->
 put(Key, Val, P) ->
     maps:put(Key, Val, P).
 
-get(Key, Val) ->
-    maps:get(Key, Val).
+get(Key, P) ->
+    maps:get(Key, P).
 
-get(Key, Val, Default) ->
-    maps:get(Key, Val, Default).
+get(Key, P, Default) ->
+    maps:get(Key, P, Default).
 
 append(Key, Val, P) ->
     L = get(Key, P, []),

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -22,7 +22,7 @@ setup() ->
     meck:expect(ejabberd_hooks, run_fold,
                 fun(privacy_check_packet, _, _, _) -> allow end),
     meck:expect(ejabberd_hooks, run_fold,
-                fun(check_bl_c2s, _, _) -> false end),
+                fun(check_bl_c2s, A, _) -> A end),
 
     meck:new(ejabberd_config),
     meck:expect(ejabberd_config, get_local_option, fun default_local_option/1),

--- a/apps/ejabberd/test/ejabberd_hooks_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_hooks_SUITE.erl
@@ -32,6 +32,11 @@ init_per_suite(C) ->
 end_per_suite(_C) ->
     application:stop(exometer).
 
+init_per_testcase(_, C) ->
+    ejabberd_hooks:start_link(),
+    ets:new(local_config, [named_table]),
+    C.
+
 a_fun_can_be_added(_) ->
     given_hooks_started(),
 
@@ -78,30 +83,31 @@ a_module_fun_can_be_removed(_) ->
 
 hooks_run_launches_nullary_fun(_) ->
     given_hooks_started(),
-    given_module(hook_mod, fun_nullary, fun() -> success0 end),
+    given_module(hook_mod, fun_nullary, fun(_) -> #{result => success0} end),
     given_hook_added(test_run_hook, hook_mod, fun_nullary, 1),
 
     %% when
     ejabberd_hooks:run(test_run_hook, ?HOST, []),
 
     %% then
-    [{_,{hook_mod,fun_nullary,[]}, success0}] = meck:history(hook_mod).
+    H = meck:history(hook_mod),
+    [{_,{hook_mod,fun_nullary,[#{}]}, #{result := success0}}] = H.
 
 hooks_run_launches_unary_fun(_) ->
     given_hooks_started(),
-    given_module(hook_mod, fun_onearg, fun(oneval) -> success1 end),
+    given_module(hook_mod, fun_onearg, fun(Acc, Val) -> maps:put(result, Val, Acc) end),
     given_hook_added(test_run_hook, hook_mod, fun_onearg, 1),
 
     %% when
     ejabberd_hooks:run(test_run_hook, ?HOST, [oneval]),
 
     %% then
-    [{_,{hook_mod,fun_onearg,[oneval]}, success1}] = meck:history(hook_mod).
+    [{_,{hook_mod,fun_onearg,[#{}, oneval]}, #{result := oneval}}] = meck:history(hook_mod).
 
 hooks_run_ignores_different_arity_funs(_) ->
     given_hooks_started(),
-    given_module(hook_mod, fun_onearg, fun(unused) -> never_return end),
-    given_fun(hook_mod, fun_twoarg, fun(one,two)-> success2 end),
+    given_module(hook_mod, fun_onearg, fun(#{}, unused) -> never_return end),
+    given_fun(hook_mod, fun_twoarg, fun(#{}, one,two)-> #{r => success2} end),
 
     given_hook_added(test_run_hook, hook_mod, fun_onearg, 1),
     given_hook_added(test_run_hook, hook_mod, fun_twoarg, 1),
@@ -110,7 +116,7 @@ hooks_run_ignores_different_arity_funs(_) ->
     ejabberd_hooks:run(test_run_hook, ?HOST, [one, two]),
 
     %% then
-    [{_,{hook_mod,fun_twoarg,[one,two]}, success2}] = meck:history(hook_mod).
+    [{_,{hook_mod,fun_twoarg,[#{}, one,two]}, #{r := success2}}] = meck:history(hook_mod).
 
 hooks_run_stops_when_fun_returns_stop(_) ->
     given_hooks_started(),
@@ -121,10 +127,10 @@ hooks_run_stops_when_fun_returns_stop(_) ->
     given_hook_added(test_run_hook, hook_mod, another_fun, 2),
 
     %% when
-    ejabberd_hooks:run(test_run_hook, ?HOST, [x]),
+    ejabberd_hooks:run(test_run_hook, ?HOST, []),
 
     %% then
-    [{_,{hook_mod,a_fun,[x]}, stop}] = meck:history(hook_mod).
+    [{_,{hook_mod,a_fun,[#{}]}, stop}] = meck:history(hook_mod).
 
 
 hooks_run_fold_folds_with_unary_fun(_) ->

--- a/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
+++ b/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
@@ -62,7 +62,7 @@ meck_mods(_) -> [exometer, ejabberd_sm, ejabberd_local, ejabberd_config].
 cleaner_runs_hook_on_nodedown(_Config) ->
     {ok, Cleaner} = mongoose_cleaner:start_link(),
     Self = self(),
-    NotifySelf = fun (Node) -> Self ! {got_nodedown, Node} end,
+    NotifySelf = fun (_Acc, Node) -> Self ! {got_nodedown, Node} end,
     ejabberd_hooks:add(node_cleanup, global, undefined, NotifySelf, 50),
 
     FakeNode = fakename@fakehost,
@@ -78,7 +78,7 @@ auth_anonymous(_Config) ->
     ejabberd_auth_anonymous:start(?HOST),
     {U, S, R, JID, SID} = get_fake_session(),
     Info = [{auth_module, ejabberd_auth_anonymous}],
-    ejabberd_auth_anonymous:register_connection(SID, JID, Info),
+    ejabberd_auth_anonymous:register_connection(#{}, SID, JID, Info),
     true = ejabberd_auth_anonymous:anonymous_user_exist(U, S),
     ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),
     false = ejabberd_auth_anonymous:anonymous_user_exist(U, S).
@@ -88,7 +88,7 @@ last(_Config) ->
     {U, S, R, _JID, SID} = get_fake_session(),
     not_found = mod_last:get_last_info(U, S),
     Status1 = <<"status1">>,
-    ok = mod_last:on_presence_update(U, S, R, Status1),
+    #{} = mod_last:on_presence_update(#{}, U, S, R, Status1),
     {ok, TS1, Status1} = mod_last:get_last_info(U, S),
     timer:sleep(2000),
     ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),


### PR DESCRIPTION
This PR addresses #980 and is only for review and discussion

Proposed changes include:

```
change to ejabberd_hooks:run so that it passes an empty map as first arg
modification to all handlers that are called by :run
modification of 20 folded hooks so that they accept and return a map
a new module for encapsulating accumulators
```

It is freshly rebased and passes most tests.
